### PR TITLE
Final update for 1.01

### DIFF
--- a/RAS_Inventory_V1.ps1
+++ b/RAS_Inventory_V1.ps1
@@ -3,22 +3,22 @@
 
 <#
 .SYNOPSIS
-	Creates a complete inventory of Parallels Remote Application Server.
+	Creates a complete inventory of a V17 Parallels Remote Application Server.
 .DESCRIPTION
-	Creates a complete inventory of Parallels Remote Application Server (RAS) using 
+	Creates a complete inventory of a V17 Parallels Remote Application Server (RAS) using 
 	Microsoft PowerShell, Word, plain text, or HTML.
 	
 	The script requires at least PowerShell version 3 but runs best in version 5.
 
-	Word is NOT needed to run the script. This script will output in Text and HTML.
+	Word is NOT needed to run the script. This script outputs in Text and HTML.
 	The default output format is HTML.
 	
-	Creates an output file named RASInventory.<fileextension>.
+	Creates an output file named Parallels_RAS.<fileextension>.
 	
 	You do NOT have to run this script on a server running RAS. This script was developed 
 	and run from a Windows 10 VM.
 
-	Word and PDF document includes a Cover Page, Table of Contents and Footer.
+	Word and PDF document includes a Cover Page, Table of Contents, and Footer.
 	Includes support for the following language versions of Microsoft Word:
 		Catalan
 		Chinese
@@ -33,12 +33,59 @@
 		Spanish
 		Swedish
 
+.PARAMETER ServerName
+	Specifies which RAS server to use to run the script against.
+	
+	ServerName can be entered as the NetBIOS name, FQDN, localhost, or IP Address.
+	
+	If entered as localhost, the actual computer name is determined and used.
+	
+	If entered as an IP address, an attempt is made to determine and use the actual 
+	computer name.
+	
+	Default value is LocalHost
+.PARAMETER User
+	Username to use for the connection to the RAS server.
+
+	Default value is contained in $env:username
 .PARAMETER HTML
 	Creates an HTML file with an .html extension.
 	
 	HTML is now the default report format.
 	
 	This parameter is set True if no other output format is selected.
+.PARAMETER Text
+	Creates a formatted text file with a .txt extension.
+	
+	This parameter is disabled by default.
+.PARAMETER Folder
+	Specifies the optional output folder to save the output report. 
+.PARAMETER AddDateTime
+	Adds a date timestamp to the end of the file name.
+	
+	The timestamp is in the format of yyyy-MM-dd_HHmm.
+	June 1, 2022 at 6PM is 2022-06-01_1800.
+	
+	Output filename will be ReportName_2022-06-01_1800.<ext>.
+	
+	This parameter is disabled by default.
+	This parameter has an alias of ADT.
+.PARAMETER Dev
+	Clears errors at the beginning of the script.
+	Outputs all errors to a text file at the end of the script.
+	
+	This is used when the script developer requests more troubleshooting data.
+	The text file is placed in the same folder from where the script is run.
+	
+	This parameter is disabled by default.
+.PARAMETER Log
+	Generates a log file for troubleshooting.
+.PARAMETER ScriptInfo
+	Outputs information about the script to a text file.
+	The text file is placed in the same folder from where the script is run.
+	
+	This parameter is disabled by default.
+	This parameter has an alias of SI.
 .PARAMETER MSWord
 	SaveAs DOCX file
 	
@@ -53,20 +100,6 @@
 	This parameter uses Word's SaveAs PDF capability.
 
 	This parameter is disabled by default.
-.PARAMETER Text
-	Creates a formatted text file with a .txt extension.
-	
-	This parameter is disabled by default.
-.PARAMETER AddDateTime
-	Adds a date timestamp to the end of the file name.
-	
-	The timestamp is in the format of yyyy-MM-dd_HHmm.
-	June 1, 2019 at 6PM is 2021-06-01_1800.
-	
-	Output filename will be ReportName_2021-06-01_1800.<ext>.
-	
-	This parameter is disabled by default.
-	This parameter has an alias of ADT.
 .PARAMETER CompanyAddress
 	Company Address to use for the Cover Page, if the Cover Page has the Address field.
 	
@@ -84,7 +117,7 @@
 	This parameter is only valid with the MSWORD and PDF output parameters.
 	This parameter has an alias of CA.
 .PARAMETER CompanyEmail
-	Company Email to use for the Cover Page, if the Cover Page has the Email field. 
+	Company Email to use for the Cover Page if the Cover Page has the Email field. 
 	
 	The following Cover Pages have an Email field:
 		Facet (Word 2013/2016)
@@ -92,7 +125,7 @@
 	This parameter is only valid with the MSWORD and PDF output parameters.
 	This parameter has an alias of CE.
 .PARAMETER CompanyFax
-	Company Fax to use for the Cover Page, if the Cover Page has the Fax field. 
+	Company Fax to use for the Cover Page if the Cover Page has the Fax field. 
 	
 	The following Cover Pages have a Fax field:
 		Contrast (Word 2010)
@@ -120,7 +153,7 @@
 	This parameter has an alias of CPh.
 .PARAMETER CoverPage
 	What Microsoft Word Cover Page to use.
-	Only Word 2010, 2013 and 2016 are supported.
+	Only Word 2010, 2013, and 2016 are supported.
 	(default cover pages in Word en-US)
 
 	Valid input is:
@@ -128,8 +161,8 @@
 		Annual (Word 2010. Doesn't work well for this report)
 		Austere (Word 2010. Works)
 		Austin (Word 2010/2013/2016. Doesn't work in 2013 or 2016, mostly 
-		works in 2010 but Subtitle/Subject & Author fields need to be moved 
-		after title box is moved up)
+		works in 2010, but Subtitle/Subject & Author fields need moving after the 
+		title box is moved up)
 		Banded (Word 2013/2016. Works)
 		Conservative (Word 2010. Works)
 		Contrast (Word 2010. Works)
@@ -144,16 +177,16 @@
 		Ion (Light) (Word 2013/2016. Top date doesn't fit; box needs to be 
 		manually resized or font changed to 8 point)
 		Mod (Word 2010. Works)
-		Motion (Word 2010/2013/2016. Works if top date is manually changed to 
+		Motion (Word 2010/2013/2016. Works if the top date is manually changed to 
 		36 point)
-		Newsprint (Word 2010. Works but date is not populated)
+		Newsprint (Word 2010. Works but the date is not populated)
 		Perspective (Word 2010. Works)
 		Pinstripes (Word 2010. Works)
 		Puzzle (Word 2010. Top date doesn't fit; box needs to be manually 
 		resized or font changed to 14 point)
 		Retrospect (Word 2013/2016. Works)
 		Semaphore (Word 2013/2016. Works)
-		Sideline (Word 2010/2013/2016. Doesn't work in 2013 or 2016, works in 
+		Sideline (Word 2010/2013/2016. Doesn't work in 2013 or 2016. Works in 
 		2010)
 		Slice (Dark) (Word 2013/2016. Doesn't work)
 		Slice (Light) (Word 2013/2016. Doesn't work)
@@ -166,39 +199,11 @@
 	The default value is Sideline.
 	This parameter has an alias of CP.
 	This parameter is only valid with the MSWORD and PDF output parameters.
-.PARAMETER Dev
-	Clears errors at the beginning of the script.
-	Outputs all errors to a text file at the end of the script.
-	
-	This is used when the script developer requests more troubleshooting data.
-	The text file is placed in the same folder from where the script is run.
-	
-	This parameter is disabled by default.
-.PARAMETER Folder
-	Specifies the optional output folder to save the output report. 
-.PARAMETER From
-	Specifies the username for the From email address.
-	
-	If SmtpServer or To are used, this is a required parameter.
-.PARAMETER Log
-	Generates a log file for troubleshooting.
-.PARAMETER ScriptInfo
-	Outputs information about the script to a text file.
-	The text file is placed in the same folder from where the script is run.
-	
-	This parameter is disabled by default.
-	This parameter has an alias of SI.
-.PARAMETER ServerName
-	Specifies which RAS server to use to run the script against.
-	
-	ServerName can be entered as the NetBIOS name, FQDN, localhost or IP Address.
-	
-	If entered as localhost, the actual computer name is determined and used.
-	
-	If entered as an IP address, an attempt is made to determine and use the actual 
-	computer name.
-	
-	Default value is LocalHost
+.PARAMETER UserName
+	Username to use for the Cover Page and Footer.
+	The default value is contained in $env:username
+	This parameter has an alias of UN.
+	This parameter is only valid with the MSWORD and PDF output parameters.
 .PARAMETER SmtpPort
 	Specifies the SMTP port for the SmtpServer. 
 	The default is 25.
@@ -206,19 +211,14 @@
 	Specifies the optional email server to send the output report(s). 
 	
 	If From or To are used, this is a required parameter.
+.PARAMETER From
+	Specifies the username for the From email address.
+	
+	If SmtpServer or To are used, this is a required parameter.
 .PARAMETER To
 	Specifies the username for the To email address.
 	
 	If SmtpServer or From are used, this is a required parameter.
-.PARAMETER User
-	Username to use for the connection to the RAS server.
-
-	Default value is contained in $env:username
-.PARAMETER UserName
-	Username to use for the Cover Page and Footer.
-	The default value is contained in $env:username
-	This parameter has an alias of UN.
-	This parameter is only valid with the MSWORD and PDF output parameters.
 .PARAMETER UseSSL
 	Specifies whether to use SSL for the SmtpServer.
 	The default is False.
@@ -249,16 +249,11 @@
 		Carl Webster for the User Name (alias UN).
 
 	Outputs to PDF.
-	Prompts for credentials for the LocalHost RAS Server.
+	Prompts for credentials for the Localhost RAS Server.
 .EXAMPLE
-	PS C:\PSScript .\RAS_Inventory_V1.ps1 -CompanyName "Sherlock Holmes 
-	Consulting"
-	-CoverPage Exposure 
-	-UserName "Dr. Watson"
-	-CompanyAddress "221B Baker Street, London, England"
-	-CompanyFax "+44 1753 276600"
-	-CompanyPhone "+44 1753 276200"
-	-MSWord
+	PS C:\PSScript .\RAS_Inventory_V1.ps1 -CompanyName "Sherlock Holmes Consulting"
+	-CoverPage Exposure -UserName "Dr. Watson" -CompanyAddress "221B Baker Street, London, 
+	England" -CompanyFax "+44 1753 276600" -CompanyPhone "+44 1753 276200" -MSWord
 	
 	Will use:
 		Sherlock Holmes Consulting for the Company Name.
@@ -271,11 +266,8 @@
 	Outputs to Microsoft Word.
 	Prompts for credentials for the LocalHost RAS Server.
 .EXAMPLE
-	PS C:\PSScript .\RAS_Inventory_V1.ps1 -CompanyName "Sherlock Holmes 
-	Consulting"
-	-CoverPage Facet 
-	-UserName "Dr. Watson"
-	-CompanyEmail SuperSleuth@SherlockHolmes.com
+	PS C:\PSScript .\RAS_Inventory_V1.ps1 -CompanyName "Sherlock Holmes Consulting"
+	-CoverPage Facet -UserName "Dr. Watson" -CompanyEmail SuperSleuth@SherlockHolmes.com
 	-PDF
 
 	Will use:
@@ -287,110 +279,96 @@
 	Outputs to PDF.
 	Prompts for credentials for the LocalHost RAS Server.
 .EXAMPLE
-	PS C:\PSScript > .\RAS_Inventory_V1.ps1 
-	-SmtpServer mail.domain.tld
-	-From XDAdmin@domain.tld 
-	-To ITGroup@domain.tld	
-	-Text
+    PS C:\PSScript >.\RAS_Inventory_V1.ps1 -SmtpServer mail.domain.tld -From 
+    XDAdmin@domain.tld -To ITGroup@domain.tld -Text
 
-	The script will use the email server mail.domain.tld, sending from XDAdmin@domain.tld, 
-	sending to ITGroup@domain.tld.
+    The script uses the email server mail.domain.tld, sending from XDAdmin@domain.tld,
+    sending to ITGroup@domain.tld.
 
-	The script will use the default SMTP port 25 and will not use SSL.
+    The script uses the default SMTP port 25 and does not use SSL.
 
-	If the current user's credentials are not valid to send email, 
-	the user will be prompted to enter valid credentials.
+    If the current user's credentials are not valid to send an email, the script prompts 
+    the user to enter valid credentials.
 
-	Outputs to a text file.
-	Prompts for credentials for the LocalHost RAS Server.
+    Outputs to a text file.
+    Prompts for credentials for the Localhost RAS Server.
 .EXAMPLE
-	PS C:\PSScript > .\RAS_Inventory_V1.ps1 
-	-SmtpServer mailrelay.domain.tld
-	-From Anonymous@domain.tld 
-	-To ITGroup@domain.tld	
+    PS C:\PSScript >.\RAS_Inventory_V1.ps1 -SmtpServer mailrelay.domain.tld -From 
+    Anonymous@domain.tld -To ITGroup@domain.tld
 
-	***SENDING UNAUTHENTICATED EMAIL***
+    ***SENDING UNAUTHENTICATED EMAIL***
 
-	The script will use the email server mailrelay.domain.tld, sending from 
-	anonymous@domain.tld, sending to ITGroup@domain.tld.
+    The script uses the email server mailrelay.domain.tld, sending from
+    anonymous@domain.tld, sending to ITGroup@domain.tld.
 
-	To send unauthenticated email using an email relay server requires the From email account 
-	to use the name Anonymous.
+    To send an unauthenticated email using an email relay server requires the From email 
+    account to use the name Anonymous.
 
-	The script will use the default SMTP port 25 and will not use SSL.
-	
-	***GMAIL/G SUITE SMTP RELAY***
-	https://support.google.com/a/answer/2956491?hl=en
-	https://support.google.com/a/answer/176600?hl=en
+    The script uses the default SMTP port 25 and does not use SSL.
 
-	To send email using a Gmail or g-suite account, you may have to turn ON
-	the "Less secure app access" option on your account.
-	***GMAIL/G SUITE SMTP RELAY***
+    ***GMAIL/G SUITE SMTP RELAY***
+    https://support.google.com/a/answer/2956491?hl=en
+    https://support.google.com/a/answer/176600?hl=en
 
-	The script will generate an anonymous secure password for the anonymous@domain.tld 
-	account.
+    To send an email using a Gmail or g-suite account, you may have to turn ON the "Less 
+    secure app access" option on your account.
 
-	Outputs, by default, to HTML.
-	Prompts for credentials for the LocalHost RAS Server.
+    ***GMAIL/G SUITE SMTP RELAY***
+
+    The script generates an anonymous, secure password for the anonymous@domain.tld
+    account.
+
+    Outputs, by default, to HTML.
+    Prompts for credentials for the LocalHost RAS Server.
 .EXAMPLE
-	PS C:\PSScript > .\RAS_Inventory_V1.ps1 
-	-SmtpServer labaddomain-com.mail.protection.outlook.com
-	-UseSSL
-	-From SomeEmailAddress@labaddomain.com 
-	-To ITGroupDL@labaddomain.com	
+    PS C:\PSScript >.\RAS_Inventory_V1.ps1 -SmtpServer 
+    labaddomain-com.mail.protection.outlook.com -UseSSL -From 
+    SomeEmailAddress@labaddomain.com -To ITGroupDL@labaddomain.com
 
-	***OFFICE 365 Example***
+    ***OFFICE 365 Example***
+    https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multifunction-device-or-application-to-send-email-using-office-3
 
-	https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multifunction-device-or-application-to-send-email-using-office-3
-	
-	This uses Option 2 from the above link.
-	
-	***OFFICE 365 Example***
+    This uses Option 2 from the above link.
 
-	The script will use the email server labaddomain-com.mail.protection.outlook.com, 
-	sending from SomeEmailAddress@labaddomain.com, sending to ITGroupDL@labaddomain.com.
+    ***OFFICE 365 Example***
 
-	The script will use the default SMTP port 25 and will use SSL.
+    The script uses the email server labaddomain-com.mail.protection.outlook.com,
+    sending from SomeEmailAddress@labaddomain.com, and sending to 
+	ITGroupDL@labaddomain.com.
 
-	Outputs, by default, to HTML.
-	Prompts for credentials for the LocalHost RAS Server.
+    The script uses the default SMTP port 25 and SSL.
+
+    Outputs, by default, to HTML.
+    Prompts for credentials for the LocalHost RAS Server.
 .EXAMPLE
-	PS C:\PSScript > .\RAS_Inventory_V1.ps1 
-	-SmtpServer smtp.office365.com 
-	-SmtpPort 587
-	-UseSSL 
-	-From Webster@CarlWebster.com 
-	-To ITGroup@CarlWebster.com	
+    PS C:\PSScript >.\RAS_Inventory_V1.ps1 -SmtpServer smtp.office365.com -SmtpPort 587 
+    -UseSSL -From Webster@CarlWebster.com -To ITGroup@CarlWebster.com
 
-	The script will use the email server smtp.office365.com on port 587 using SSL, 
-	sending from webster@carlwebster.com, sending to ITGroup@carlwebster.com.
+    The script uses the email server smtp.office365.com on port 587 using SSL, sending from 
+    webster@carlwebster.com, and sending to ITGroup@carlwebster.com.
 
-	If the current user's credentials are not valid to send email, 
-	the user will be prompted to enter valid credentials.
+    If the current user's credentials are not valid to send an email, the script prompts 
+    the user to enter valid credentials.
 
-	Outputs, by default, to HTML.
-	Prompts for credentials for the LocalHost RAS Server.
+    Outputs, by default, to HTML.
+    Prompts for credentials for the LocalHost RAS Server.
 .EXAMPLE
-	PS C:\PSScript > .\RAS_Inventory_V1.ps1 
-	-SmtpServer smtp.gmail.com 
-	-SmtpPort 587
-	-UseSSL 
-	-From Webster@CarlWebster.com 
-	-To ITGroup@CarlWebster.com	
+    PS C:\PSScript >.\RAS_Inventory_V1.ps1 -SmtpServer smtp.gmail.com -SmtpPort 587 
+    -UseSSL -From Webster@CarlWebster.com -To ITGroup@CarlWebster.com
 
-	*** NOTE ***
-	To send email using a Gmail or g-suite account, you may have to turn ON
-	the "Less secure app access" option on your account.
-	*** NOTE ***
-	
-	The script will use the email server smtp.gmail.com on port 587 using SSL, 
-	sending from webster@gmail.com, sending to ITGroup@carlwebster.com.
+    *** NOTE ***
+    To send an email using a Gmail or g-suite account, you may have to turn ON the "Less 
+    secure app access" option on your account.
+    *** NOTE ***
 
-	If the current user's credentials are not valid to send email, 
-	the user will be prompted to enter valid credentials.
+    The script uses the email server smtp.gmail.com on port 587 using SSL, sending from 
+    webster@gmail.com, and sending to ITGroup@carlwebster.com.
 
-	Outputs, by default, to HTML.
-	Prompts for credentials for the LocalHost RAS Server.
+    If the current user's credentials are not valid to send an email, the script prompts 
+    the user to enter valid credentials.
+
+    Outputs, by default, to HTML.
+    Prompts for credentials for the LocalHost RAS Server.
 .INPUTS
 	None.  You cannot pipe objects to this script.
 .OUTPUTS
@@ -398,9 +376,9 @@
 	text document.
 .NOTES
 	NAME: RAS_Inventory_V1.ps1
-	VERSION: 1.00
+	VERSION: 1.01
 	AUTHOR: Carl Webster
-	LASTEDIT: August 4, 2020
+	LASTEDIT: April 19, 2021
 #>
 
 
@@ -409,21 +387,40 @@
 
 Param(
 	[parameter(Mandatory=$False)] 
+	[string]$ServerName="LocalHost",
+	
+	[parameter(Mandatory=$False)] 
+	[string]$User=$env:username,
+	
+	[parameter(Mandatory=$False)] 
 	[Switch]$HTML=$False,
 
+	[parameter(Mandatory=$False)] 
+	[Switch]$Text=$False,
+
+	[parameter(Mandatory=$False)] 
+	[string]$Folder="",
+	
+	[parameter(Mandatory=$False)] 
+	[Alias("ADT")]
+	[Switch]$AddDateTime=$False,
+	
+	[parameter(Mandatory=$False)] 
+	[Switch]$Dev=$False,
+	
+	[parameter(Mandatory=$False)] 
+	[Switch]$Log=$False,
+	
+	[parameter(Mandatory=$False)] 
+	[Alias("SI")]
+	[Switch]$ScriptInfo=$False,
+	
 	[parameter(ParameterSetName="WordPDF",Mandatory=$False)] 
 	[Switch]$MSWord=$False,
 
 	[parameter(ParameterSetName="WordPDF",Mandatory=$False)] 
 	[Switch]$PDF=$False,
 
-	[parameter(Mandatory=$False)] 
-	[Switch]$Text=$False,
-
-	[parameter(Mandatory=$False)] 
-	[Alias("ADT")]
-	[Switch]$AddDateTime=$False,
-	
 	[parameter(ParameterSetName="WordPDF",Mandatory=$False)] 
 	[Alias("CA")]
 	[ValidateNotNullOrEmpty()]
@@ -454,25 +451,11 @@ Param(
 	[ValidateNotNullOrEmpty()]
 	[string]$CoverPage="Sideline", 
 
-	[parameter(Mandatory=$False)] 
-	[Switch]$Dev=$False,
-	
-	[parameter(Mandatory=$False)] 
-	[string]$Folder="",
-	
-	[parameter(Mandatory=$False)] 
-	[string]$From="",
+	[parameter(ParameterSetName="WordPDF",Mandatory=$False)] 
+	[Alias("UN")]
+	[ValidateNotNullOrEmpty()]
+	[string]$UserName=$env:username,
 
-	[parameter(Mandatory=$False)] 
-	[Switch]$Log=$False,
-	
-	[parameter(Mandatory=$False)] 
-	[Alias("SI")]
-	[Switch]$ScriptInfo=$False,
-	
-	[parameter(Mandatory=$False)] 
-	[string]$ServerName="LocalHost",
-	
 	[parameter(Mandatory=$False)] 
 	[int]$SmtpPort=25,
 
@@ -480,12 +463,7 @@ Param(
 	[string]$SmtpServer="",
 
 	[parameter(Mandatory=$False)] 
-	[string]$User=$env:username,
-	
-	[parameter(ParameterSetName="WordPDF",Mandatory=$False)] 
-	[Alias("UN")]
-	[ValidateNotNullOrEmpty()]
-	[string]$UserName=$env:username,
+	[string]$From="",
 
 	[parameter(Mandatory=$False)] 
 	[string]$To="",
@@ -503,6 +481,17 @@ Param(
 
 #Version 1.0 released to the community on 5-August-2020
 #
+#Version 1.01 19-Apr-2021
+#	Added a message to the error message for the missing RAS module
+#		Added a link to the V1 ReadMe file
+#	Added the missing License section for published RDSH applications to Text and HTML output
+#	Changed all Write-Verbose statements from Get-Date to Get-Date -Format G as requested by Guy Leech
+#	Changed the font size of Word/PDF tables from 11 to 10 to prevent most word wrapping to multiple lines
+#	Fixed several invalid $Null comparisons
+#	Reorder Parameters in an order recommended by Guy Leech
+#	Updated Function SetWordCellFormat to the latest version
+#	Updated the ReadMe file
+
 
 Set-StrictMode -Version Latest
 
@@ -517,24 +506,24 @@ If($MSWord -eq $False -and $PDF -eq $False -and $Text -eq $False -and $HTML -eq 
 
 If($MSWord)
 {
-	Write-Verbose "$(Get-Date): MSWord is set"
+	Write-Verbose "$(Get-Date -Format G): MSWord is set"
 }
 If($PDF)
 {
-	Write-Verbose "$(Get-Date): PDF is set"
+	Write-Verbose "$(Get-Date -Format G): PDF is set"
 }
 If($Text)
 {
-	Write-Verbose "$(Get-Date): Text is set"
+	Write-Verbose "$(Get-Date -Format G): Text is set"
 }
 If($HTML)
 {
-	Write-Verbose "$(Get-Date): HTML is set"
+	Write-Verbose "$(Get-Date -Format G): HTML is set"
 }
 
 If($Folder -ne "")
 {
-	Write-Verbose "$(Get-Date): Testing folder path"
+	Write-Verbose "$(Get-Date -Format G): Testing folder path"
 	#does it exist
 	If(Test-Path $Folder -EA 0)
 	{
@@ -542,7 +531,7 @@ If($Folder -ne "")
 		If(Test-Path $Folder -pathType Container -EA 0)
 		{
 			#it exists and it is a folder
-			Write-Verbose "$(Get-Date): Folder path $Folder exists and is a folder"
+			Write-Verbose "$(Get-Date -Format G): Folder path $Folder exists and is a folder"
 		}
 		Else
 		{
@@ -598,12 +587,12 @@ If($Log)
 	try 
 	{
 		Start-Transcript -Path $Script:LogPath -Force -Verbose:$false | Out-Null
-		Write-Verbose "$(Get-Date): Transcript/log started at $Script:LogPath"
+		Write-Verbose "$(Get-Date -Format G): Transcript/log started at $Script:LogPath"
 		$Script:StartLog = $true
 	} 
 	catch 
 	{
-		Write-Verbose "$(Get-Date): Transcript/log failed at $Script:LogPath"
+		Write-Verbose "$(Get-Date -Format G): Transcript/log failed at $Script:LogPath"
 		$Script:StartLog = $false
 	}
 }
@@ -696,21 +685,23 @@ If($MSWord -or $PDF)
 	#the following values were attained from 
 	#http://groovy.codehaus.org/modules/scriptom/1.6.0/scriptom-office-2K3-tlb/apidocs/
 	#http://msdn.microsoft.com/en-us/library/office/aa211923(v=office.11).aspx
-	[int]$wdAlignPageNumberRight = 2
-	[long]$wdColorGray15 = 14277081
-	#[long]$wdColorGray05 = 15987699 
-	[int]$wdMove = 0
-	[int]$wdSeekMainDocument = 0
-	[int]$wdSeekPrimaryFooter = 4
-	[int]$wdStory = 6
-	#[int]$wdColorRed = 255
-	#[int]$wdColorBlack = 0
-	[int]$wdWord2007 = 12
-	[int]$wdWord2010 = 14
-	[int]$wdWord2013 = 15
-	[int]$wdWord2016 = 16
+	[int]$wdAlignPageNumberRight  = 2
+	[int]$wdMove                  = 0
+	[int]$wdSeekMainDocument      = 0
+	[int]$wdSeekPrimaryFooter     = 4
+	[int]$wdStory                 = 6
+	[int]$wdColorBlack            = 0
+	[int]$wdColorGray05           = 15987699 
+	[int]$wdColorGray15           = 14277081
+	[int]$wdColorRed              = 255
+	[int]$wdColorWhite            = 16777215
+	[int]$wdColorYellow           = 65535
+	[int]$wdWord2007              = 12
+	[int]$wdWord2010              = 14
+	[int]$wdWord2013              = 15
+	[int]$wdWord2016              = 16
 	[int]$wdFormatDocumentDefault = 16
-	[int]$wdFormatPDF = 17
+	[int]$wdFormatPDF             = 17
 	#http://blogs.technet.com/b/heyscriptingguy/archive/2006/03/01/how-can-i-right-align-a-single-column-in-a-word-table.aspx
 	#http://msdn.microsoft.com/en-us/library/office/ff835817%28v=office.15%29.aspx
 	#[int]$wdAlignParagraphLeft = 0
@@ -1365,7 +1356,7 @@ Function validObject( [object] $object, [string] $topLevel )
 
 Function SetupWord
 {
-	Write-Verbose "$(Get-Date): Setting up Word"
+	Write-Verbose "$(Get-Date -Format G): Setting up Word"
     
 	If(!$AddDateTime)
 	{
@@ -1385,7 +1376,7 @@ Function SetupWord
 	}
 
 	# Setup word for output
-	Write-Verbose "$(Get-Date): Create Word comObject."
+	Write-Verbose "$(Get-Date -Format G): Create Word comObject."
 	$Script:Word = New-Object -comobject "Word.Application" -EA 0 4>$Null
 	
 	If(!$? -or $Null -eq $Script:Word)
@@ -1403,7 +1394,7 @@ Function SetupWord
 		AbortScript
 	}
 
-	Write-Verbose "$(Get-Date): Determine Word language value"
+	Write-Verbose "$(Get-Date -Format G): Determine Word language value"
 	If( ( validStateProp $Script:Word Language Value__ ) )
 	{
 		[int]$Script:WordLanguageValue = [int]$Script:Word.Language.Value__
@@ -1426,7 +1417,7 @@ Function SetupWord
 		"
 		AbortScript
 	}
-	Write-Verbose "$(Get-Date): Word language value is $($Script:WordLanguageValue)"
+	Write-Verbose "$(Get-Date -Format G): Word language value is $($Script:WordLanguageValue)"
 	
 	$Script:WordCultureCode = GetCulture $Script:WordLanguageValue
 	
@@ -1491,7 +1482,7 @@ Function SetupWord
 	#only validate CompanyName if the field is blank
 	If([String]::IsNullOrEmpty($CompanyName))
 	{
-		Write-Verbose "$(Get-Date): Company name is blank. Retrieve company name from registry."
+		Write-Verbose "$(Get-Date -Format G): Company name is blank. Retrieve company name from registry."
 		$TmpName = ValidateCompanyName
 		
 		If([String]::IsNullOrEmpty($TmpName))
@@ -1511,7 +1502,7 @@ Function SetupWord
 		Else
 		{
 			$Script:CoName = $TmpName
-			Write-Verbose "$(Get-Date): Updated company name to $($Script:CoName)"
+			Write-Verbose "$(Get-Date -Format G): Updated company name to $($Script:CoName)"
 		}
 	}
 	Else
@@ -1521,7 +1512,7 @@ Function SetupWord
 
 	If($Script:WordCultureCode -ne "en-")
 	{
-		Write-Verbose "$(Get-Date): Check Default Cover Page for $($WordCultureCode)"
+		Write-Verbose "$(Get-Date -Format G): Check Default Cover Page for $($WordCultureCode)"
 		[bool]$CPChanged = $False
 		Switch ($Script:WordCultureCode)
 		{
@@ -1624,19 +1615,19 @@ Function SetupWord
 
 		If($CPChanged)
 		{
-			Write-Verbose "$(Get-Date): Changed Default Cover Page from Sideline to $($CoverPage)"
+			Write-Verbose "$(Get-Date -Format G): Changed Default Cover Page from Sideline to $($CoverPage)"
 		}
 	}
 
-	Write-Verbose "$(Get-Date): Validate cover page $($CoverPage) for culture code $($Script:WordCultureCode)"
+	Write-Verbose "$(Get-Date -Format G): Validate cover page $($CoverPage) for culture code $($Script:WordCultureCode)"
 	[bool]$ValidCP = $False
 	
 	$ValidCP = ValidateCoverPage $Script:WordVersion $CoverPage $Script:WordCultureCode
 	
 	If(!$ValidCP)
 	{
-		Write-Verbose "$(Get-Date): Word language value $($Script:WordLanguageValue)"
-		Write-Verbose "$(Get-Date): Culture code $($Script:WordCultureCode)"
+		Write-Verbose "$(Get-Date -Format G): Word language value $($Script:WordLanguageValue)"
+		Write-Verbose "$(Get-Date -Format G): Culture code $($Script:WordCultureCode)"
 		Write-Error "
 		`n`n
 		`t`t
@@ -1653,7 +1644,7 @@ Function SetupWord
 
 	#http://jdhitsolutions.com/blog/2012/05/san-diego-2012-powershell-deep-dive-slides-and-demos/
 	#using Jeff's Demo-WordReport.ps1 file for examples
-	Write-Verbose "$(Get-Date): Load Word Templates"
+	Write-Verbose "$(Get-Date -Format G): Load Word Templates"
 
 	[bool]$Script:CoverPagesExist = $False
 	[bool]$BuildingBlocksExist = $False
@@ -1662,7 +1653,7 @@ Function SetupWord
 	#word 2010/2013/2016
 	$BuildingBlocksCollection = $Script:Word.Templates | Where-Object{$_.name -eq "Built-In Building Blocks.dotx"}
 
-	Write-Verbose "$(Get-Date): Attempt to load cover page $($CoverPage)"
+	Write-Verbose "$(Get-Date -Format G): Attempt to load cover page $($CoverPage)"
 	$part = $Null
 
 	$BuildingBlocksCollection | 
@@ -1695,16 +1686,16 @@ Function SetupWord
 
 	If(!$Script:CoverPagesExist)
 	{
-		Write-Verbose "$(Get-Date): Cover Pages are not installed or the Cover Page $($CoverPage) does not exist."
+		Write-Verbose "$(Get-Date -Format G): Cover Pages are not installed or the Cover Page $($CoverPage) does not exist."
 		Write-Warning "Cover Pages are not installed or the Cover Page $($CoverPage) does not exist."
 		Write-Warning "This report will not have a Cover Page."
 	}
 
-	Write-Verbose "$(Get-Date): Create empty word doc"
+	Write-Verbose "$(Get-Date -Format G): Create empty word doc"
 	$Script:Doc = $Script:Word.Documents.Add()
 	If($Null -eq $Script:Doc)
 	{
-		Write-Verbose "$(Get-Date): "
+		Write-Verbose "$(Get-Date -Format G): "
 		Write-Error "
 		`n`n
 		`t`t
@@ -1720,7 +1711,7 @@ Function SetupWord
 	$Script:Selection = $Script:Word.Selection
 	If($Null -eq $Script:Selection)
 	{
-		Write-Verbose "$(Get-Date): "
+		Write-Verbose "$(Get-Date -Format G): "
 		Write-Error "
 		`n`n
 		`t`t
@@ -1738,7 +1729,7 @@ Function SetupWord
 	$Script:Word.ActiveDocument.DefaultTabStop = 36
 
 	#Disable Spell and Grammar Check to resolve issue and improve performance (from Pat Coughlin)
-	Write-Verbose "$(Get-Date): Disable grammar and spell checking"
+	Write-Verbose "$(Get-Date -Format G): Disable grammar and spell checking"
 	#bug reported 1-Apr-2014 by Tim Mangan
 	#save current options first before turning them off
 	$Script:CurrentGrammarOption = $Script:Word.Options.CheckGrammarAsYouType
@@ -1749,17 +1740,17 @@ Function SetupWord
 	If($BuildingBlocksExist)
 	{
 		#insert new page, getting ready for table of contents
-		Write-Verbose "$(Get-Date): Insert new page, getting ready for table of contents"
+		Write-Verbose "$(Get-Date -Format G): Insert new page, getting ready for table of contents"
 		$part.Insert($Script:Selection.Range,$True) | Out-Null
 		$Script:Selection.InsertNewPage()
 
 		#table of contents
-		Write-Verbose "$(Get-Date): Table of Contents - $($Script:MyHash.Word_TableOfContents)"
+		Write-Verbose "$(Get-Date -Format G): Table of Contents - $($Script:MyHash.Word_TableOfContents)"
 		$toc = $BuildingBlocks.BuildingBlockEntries.Item($Script:MyHash.Word_TableOfContents)
 		If($Null -eq $toc)
 		{
-			Write-Verbose "$(Get-Date): "
-			Write-Verbose "$(Get-Date): Table of Content - $($Script:MyHash.Word_TableOfContents) could not be retrieved."
+			Write-Verbose "$(Get-Date -Format G): "
+			Write-Verbose "$(Get-Date -Format G): Table of Content - $($Script:MyHash.Word_TableOfContents) could not be retrieved."
 			Write-Warning "This report will not have a Table of Contents."
 		}
 		Else
@@ -1769,16 +1760,16 @@ Function SetupWord
 	}
 	Else
 	{
-		Write-Verbose "$(Get-Date): Table of Contents are not installed."
+		Write-Verbose "$(Get-Date -Format G): Table of Contents are not installed."
 		Write-Warning "Table of Contents are not installed so this report will not have a Table of Contents."
 	}
 
 	#set the footer
-	Write-Verbose "$(Get-Date): Set the footer"
+	Write-Verbose "$(Get-Date -Format G): Set the footer"
 	[string]$footertext = "Report created by $username"
 
 	#get the footer
-	Write-Verbose "$(Get-Date): Get the footer and format font"
+	Write-Verbose "$(Get-Date -Format G): Get the footer and format font"
 	$Script:Doc.ActiveWindow.ActivePane.view.SeekView = $wdSeekPrimaryFooter
 	#get the footer and format font
 	$footers = $Script:Doc.Sections.Last.Footers
@@ -1792,15 +1783,15 @@ Function SetupWord
 			$footer.range.Font.Bold = $True
 		}
 	} #end ForEach
-	Write-Verbose "$(Get-Date): Footer text"
+	Write-Verbose "$(Get-Date -Format G): Footer text"
 	$Script:Selection.HeaderFooter.Range.Text = $footerText
 
 	#add page numbering
-	Write-Verbose "$(Get-Date): Add page numbering"
+	Write-Verbose "$(Get-Date -Format G): Add page numbering"
 	$Script:Selection.HeaderFooter.PageNumbers.Add($wdAlignPageNumberRight) | Out-Null
 
 	FindWordDocumentEnd
-	Write-Verbose "$(Get-Date):"
+	Write-Verbose "$(Get-Date -Format G):"
 	#end of Jeff Hicks 
 }
 
@@ -1813,7 +1804,7 @@ Function UpdateDocumentProperties
 	{
 		If($Script:CoverPagesExist)
 		{
-			Write-Verbose "$(Get-Date): Set Cover Page Properties"
+			Write-Verbose "$(Get-Date -Format G): Set Cover Page Properties"
 			#8-Jun-2017 put these 4 items in alpha order
             Set-DocumentProperty -Document $Script:Doc -DocProperty Author -Value $UserName
             Set-DocumentProperty -Document $Script:Doc -DocProperty Company -Value $Script:CoName
@@ -1865,7 +1856,7 @@ Function UpdateDocumentProperties
 			[string]$abstract = (Get-Date -Format d).ToString()
 			$ab.Text = $abstract
 
-			Write-Verbose "$(Get-Date): Update the Table of Contents"
+			Write-Verbose "$(Get-Date -Format G): Update the Table of Contents"
 			#update the Table of Contents
 			$Script:Doc.TablesOfContents.item(1).Update()
 			$cp = $Null
@@ -2573,7 +2564,7 @@ Function FormatHTMLTable
 #region other HTML functions
 Function SetupHTML
 {
-	Write-Verbose "$(Get-Date): Setting up HTML"
+	Write-Verbose "$(Get-Date -Format G): Setting up HTML"
 	If(!$AddDateTime)
 	{
 		[string]$Script:HtmlFileName = "$($Script:pwdpath)\$($OutputFileName).html"
@@ -2915,7 +2906,7 @@ Function SetWordCellFormat
 		# Font size
 		[Parameter()] [ValidateNotNullOrEmpty()] [int] $Size = 0,
 		# Cell background color
-		[Parameter()] [AllowNull()] $BackgroundColor = $Null,
+		[Parameter()] [AllowNull()] [int]$BackgroundColor = $Null,
 		# Force solid background color
 		[Switch] $Solid,
 		[Switch] $Bold,
@@ -3047,7 +3038,7 @@ Function SaveandCloseDocumentandShutdownWord
 	$Script:Word.Options.CheckGrammarAsYouType = $Script:CurrentGrammarOption
 	$Script:Word.Options.CheckSpellingAsYouType = $Script:CurrentSpellingOption
 
-	Write-Verbose "$(Get-Date): Save and Close document and Shutdown Word"
+	Write-Verbose "$(Get-Date -Format G): Save and Close document and Shutdown Word"
 	If($Script:WordVersion -eq $wdWord2010)
 	{
 		#the $saveFormat below passes StrictMode 2
@@ -3056,18 +3047,18 @@ Function SaveandCloseDocumentandShutdownWord
 		#http://msdn.microsoft.com/en-us/library/microsoft.office.interop.word.wdsaveformat(v=office.14).aspx
 		If($PDF)
 		{
-			Write-Verbose "$(Get-Date): Saving as DOCX file first before saving to PDF"
+			Write-Verbose "$(Get-Date -Format G): Saving as DOCX file first before saving to PDF"
 		}
 		Else
 		{
-			Write-Verbose "$(Get-Date): Saving DOCX file"
+			Write-Verbose "$(Get-Date -Format G): Saving DOCX file"
 		}
-		Write-Verbose "$(Get-Date): Running $($Script:WordProduct) and detected operating system $($Script:RunningOS)"
+		Write-Verbose "$(Get-Date -Format G): Running $($Script:WordProduct) and detected operating system $($Script:RunningOS)"
 		$saveFormat = [Enum]::Parse([Microsoft.Office.Interop.Word.WdSaveFormat], "wdFormatDocumentDefault")
 		$Script:Doc.SaveAs([REF]$Script:WordFileName, [ref]$SaveFormat)
 		If($PDF)
 		{
-			Write-Verbose "$(Get-Date): Now saving as PDF"
+			Write-Verbose "$(Get-Date -Format G): Now saving as PDF"
 			$saveFormat = [Enum]::Parse([Microsoft.Office.Interop.Word.WdSaveFormat], "wdFormatPDF")
 			$Script:Doc.SaveAs([REF]$Script:PDFFileName, [ref]$saveFormat)
 		}
@@ -3076,25 +3067,25 @@ Function SaveandCloseDocumentandShutdownWord
 	{
 		If($PDF)
 		{
-			Write-Verbose "$(Get-Date): Saving as DOCX file first before saving to PDF"
+			Write-Verbose "$(Get-Date -Format G): Saving as DOCX file first before saving to PDF"
 		}
 		Else
 		{
-			Write-Verbose "$(Get-Date): Saving DOCX file"
+			Write-Verbose "$(Get-Date -Format G): Saving DOCX file"
 		}
-		Write-Verbose "$(Get-Date): Running $($Script:WordProduct) and detected operating system $($Script:RunningOS)"
+		Write-Verbose "$(Get-Date -Format G): Running $($Script:WordProduct) and detected operating system $($Script:RunningOS)"
 		$Script:Doc.SaveAs2([REF]$Script:WordFileName, [ref]$wdFormatDocumentDefault)
 		If($PDF)
 		{
-			Write-Verbose "$(Get-Date): Now saving as PDF"
+			Write-Verbose "$(Get-Date -Format G): Now saving as PDF"
 			$Script:Doc.SaveAs([REF]$Script:PDFFileName, [ref]$wdFormatPDF)
 		}
 	}
 
-	Write-Verbose "$(Get-Date): Closing Word"
+	Write-Verbose "$(Get-Date -Format G): Closing Word"
 	$Script:Doc.Close()
 	$Script:Word.Quit()
-	Write-Verbose "$(Get-Date): System Cleanup"
+	Write-Verbose "$(Get-Date -Format G): System Cleanup"
 	[System.Runtime.Interopservices.Marshal]::ReleaseComObject($Script:Word) | Out-Null
 	Remove-Variable -Name word -Scope Script 4>$Null
 	Remove-Variable -Name Doc  -Scope Script 4>$Null
@@ -3112,14 +3103,14 @@ Function SaveandCloseDocumentandShutdownWord
 	$wordprocess = (Get-Process 'WinWord' -ea 0) | Where-Object {$_.SessionId -eq $SessionID}
 	If($null -ne $wordprocess -and $wordprocess.Id -gt 0)
 	{
-		Write-Verbose "$(Get-Date): WinWord process is still running. Attempting to stop WinWord process # $($wordprocess.Id)"
+		Write-Verbose "$(Get-Date -Format G): WinWord process is still running. Attempting to stop WinWord process # $($wordprocess.Id)"
 		Stop-Process $wordprocess.Id -EA 0
 	}
 }
 
 Function SetupText
 {
-	Write-Verbose "$(Get-Date): Setting up Text"
+	Write-Verbose "$(Get-Date -Format G): Setting up Text"
 	[System.Text.StringBuilder] $Script:Output = New-Object System.Text.StringBuilder( 16384 )
 
 	If(!$AddDateTime)
@@ -3134,13 +3125,13 @@ Function SetupText
 
 Function SaveandCloseTextDocument
 {
-	Write-Verbose "$(Get-Date): Saving Text file"
+	Write-Verbose "$(Get-Date -Format G): Saving Text file"
 	Write-Output $Script:Output.ToString() | Out-File $Script:TextFileName 4>$Null
 }
 
 Function SaveandCloseHTMLDocument
 {
-	Write-Verbose "$(Get-Date): Saving HTML file"
+	Write-Verbose "$(Get-Date -Format G): Saving HTML file"
 	Out-File -FilePath $Script:HtmlFileName -Append -InputObject "<p></p></body></html>" 4>$Null
 }
 
@@ -3190,7 +3181,7 @@ Function ProcessDocumentOutput
 		{
 			If(Test-Path "$($Script:WordFileName)")
 			{
-				Write-Verbose "$(Get-Date): $($Script:WordFileName) is ready for use"
+				Write-Verbose "$(Get-Date -Format G): $($Script:WordFileName) is ready for use"
 				$GotFile = $True
 			}
 			Else
@@ -3203,7 +3194,7 @@ Function ProcessDocumentOutput
 		{
 			If(Test-Path "$($Script:PDFFileName)")
 			{
-				Write-Verbose "$(Get-Date): $($Script:PDFFileName) is ready for use"
+				Write-Verbose "$(Get-Date -Format G): $($Script:PDFFileName) is ready for use"
 				$GotFile = $True
 			}
 			Else
@@ -3216,7 +3207,7 @@ Function ProcessDocumentOutput
 		{
 			If(Test-Path "$($Script:TextFileName)")
 			{
-				Write-Verbose "$(Get-Date): $($Script:TextFileName) is ready for use"
+				Write-Verbose "$(Get-Date -Format G): $($Script:TextFileName) is ready for use"
 				$GotFile = $True
 			}
 			Else
@@ -3229,7 +3220,7 @@ Function ProcessDocumentOutput
 		{
 			If(Test-Path "$($Script:HTMLFileName)")
 			{
-				Write-Verbose "$(Get-Date): $($Script:HTMLFileName) is ready for use"
+				Write-Verbose "$(Get-Date -Format G): $($Script:HTMLFileName) is ready for use"
 				$GotFile = $True
 			}
 			Else
@@ -3268,72 +3259,72 @@ Function ProcessDocumentOutput
 
 Function ShowScriptOptions
 {
-	Write-Verbose "$(Get-Date): "
-	Write-Verbose "$(Get-Date): "
-	Write-Verbose "$(Get-Date): Add DateTime         : $($AddDateTime)"
+	Write-Verbose "$(Get-Date -Format G): "
+	Write-Verbose "$(Get-Date -Format G): "
+	Write-Verbose "$(Get-Date -Format G): Add DateTime         : $($AddDateTime)"
 	If($MSWORD -or $PDF)
 	{
-		Write-Verbose "$(Get-Date): Company Name         : $($Script:CoName)"
-		Write-Verbose "$(Get-Date): Company Address      : $($CompanyAddress)"
-		Write-Verbose "$(Get-Date): Company Email        : $($CompanyEmail)"
-		Write-Verbose "$(Get-Date): Company Fax          : $($CompanyFax)"
-		Write-Verbose "$(Get-Date): Company Phone        : $($CompanyPhone)"
-		Write-Verbose "$(Get-Date): Cover Page           : $($CoverPage)"
+		Write-Verbose "$(Get-Date -Format G): Company Name         : $($Script:CoName)"
+		Write-Verbose "$(Get-Date -Format G): Company Address      : $($CompanyAddress)"
+		Write-Verbose "$(Get-Date -Format G): Company Email        : $($CompanyEmail)"
+		Write-Verbose "$(Get-Date -Format G): Company Fax          : $($CompanyFax)"
+		Write-Verbose "$(Get-Date -Format G): Company Phone        : $($CompanyPhone)"
+		Write-Verbose "$(Get-Date -Format G): Cover Page           : $($CoverPage)"
 	}
-	Write-Verbose "$(Get-Date): Dev                  : $($Dev)"
+	Write-Verbose "$(Get-Date -Format G): Dev                  : $($Dev)"
 	If($Dev)
 	{
-		Write-Verbose "$(Get-Date): DevErrorFile         : $($Script:DevErrorFile)"
+		Write-Verbose "$(Get-Date -Format G): DevErrorFile         : $($Script:DevErrorFile)"
 	}
 	If($MSWord)
 	{
-		Write-Verbose "$(Get-Date): Word FileName        : $($Script:WordFileName)"
+		Write-Verbose "$(Get-Date -Format G): Word FileName        : $($Script:WordFileName)"
 	}
 	If($HTML)
 	{
-		Write-Verbose "$(Get-Date): HTML FileName        : $($Script:HtmlFileName)"
+		Write-Verbose "$(Get-Date -Format G): HTML FileName        : $($Script:HtmlFileName)"
 	} 
 	If($PDF)
 	{
-		Write-Verbose "$(Get-Date): PDF FileName         : $($Script:PDFFileName)"
+		Write-Verbose "$(Get-Date -Format G): PDF FileName         : $($Script:PDFFileName)"
 	}
 	If($Text)
 	{
-		Write-Verbose "$(Get-Date): Text FileName        : $($Script:TextFileName)"
+		Write-Verbose "$(Get-Date -Format G): Text FileName        : $($Script:TextFileName)"
 	}
-	Write-Verbose "$(Get-Date): Folder               : $($Folder)"
-	Write-Verbose "$(Get-Date): From                 : $($From)"
-	Write-Verbose "$(Get-Date): Log                  : $($Log)"
-	Write-Verbose "$(Get-Date): RAS Version          : $($Script:RASVersion)"
-	Write-Verbose "$(Get-Date): Save As HTML         : $($HTML)"
-	Write-Verbose "$(Get-Date): Save As PDF          : $($PDF)"
-	Write-Verbose "$(Get-Date): Save As TEXT         : $($TEXT)"
-	Write-Verbose "$(Get-Date): Save As WORD         : $($MSWORD)"
-	Write-Verbose "$(Get-Date): ScriptInfo           : $($ScriptInfo)"
-	Write-Verbose "$(Get-Date): Smtp Port            : $($SmtpPort)"
-	Write-Verbose "$(Get-Date): Smtp Server          : $($SmtpServer)"
-	Write-Verbose "$(Get-Date): Title                : $($Script:Title)"
-	Write-Verbose "$(Get-Date): To                   : $($To)"
-	Write-Verbose "$(Get-Date): Use SSL              : $($UseSSL)"
-	Write-Verbose "$(Get-Date): User                 : $($Script:User)"
+	Write-Verbose "$(Get-Date -Format G): Folder               : $($Folder)"
+	Write-Verbose "$(Get-Date -Format G): From                 : $($From)"
+	Write-Verbose "$(Get-Date -Format G): Log                  : $($Log)"
+	Write-Verbose "$(Get-Date -Format G): RAS Version          : $($Script:RASVersion)"
+	Write-Verbose "$(Get-Date -Format G): Save As HTML         : $($HTML)"
+	Write-Verbose "$(Get-Date -Format G): Save As PDF          : $($PDF)"
+	Write-Verbose "$(Get-Date -Format G): Save As TEXT         : $($TEXT)"
+	Write-Verbose "$(Get-Date -Format G): Save As WORD         : $($MSWORD)"
+	Write-Verbose "$(Get-Date -Format G): ScriptInfo           : $($ScriptInfo)"
+	Write-Verbose "$(Get-Date -Format G): Smtp Port            : $($SmtpPort)"
+	Write-Verbose "$(Get-Date -Format G): Smtp Server          : $($SmtpServer)"
+	Write-Verbose "$(Get-Date -Format G): Title                : $($Script:Title)"
+	Write-Verbose "$(Get-Date -Format G): To                   : $($To)"
+	Write-Verbose "$(Get-Date -Format G): Use SSL              : $($UseSSL)"
+	Write-Verbose "$(Get-Date -Format G): User                 : $($Script:User)"
 	If($MSWORD -or $PDF)
 	{
-		Write-Verbose "$(Get-Date): User Name            : $($UserName)"
+		Write-Verbose "$(Get-Date -Format G): User Name            : $($UserName)"
 	}
-	Write-Verbose "$(Get-Date): "
-	Write-Verbose "$(Get-Date): OS Detected          : $($Script:RunningOS)"
-	Write-Verbose "$(Get-Date): PoSH version         : $($Host.Version)"
-	Write-Verbose "$(Get-Date): PSCulture            : $($PSCulture)"
-	Write-Verbose "$(Get-Date): PSUICulture          : $($PSUICulture)"
+	Write-Verbose "$(Get-Date -Format G): "
+	Write-Verbose "$(Get-Date -Format G): OS Detected          : $($Script:RunningOS)"
+	Write-Verbose "$(Get-Date -Format G): PoSH version         : $($Host.Version)"
+	Write-Verbose "$(Get-Date -Format G): PSCulture            : $($PSCulture)"
+	Write-Verbose "$(Get-Date -Format G): PSUICulture          : $($PSUICulture)"
 	If($MSWORD -or $PDF)
 	{
-		Write-Verbose "$(Get-Date): Word language        : $($Script:WordLanguageValue)"
-		Write-Verbose "$(Get-Date): Word version         : $($Script:WordProduct)"
+		Write-Verbose "$(Get-Date -Format G): Word language        : $($Script:WordLanguageValue)"
+		Write-Verbose "$(Get-Date -Format G): Word version         : $($Script:WordProduct)"
 	}
-	Write-Verbose "$(Get-Date): "
-	Write-Verbose "$(Get-Date): Script start         : $($Script:StartTime)"
-	Write-Verbose "$(Get-Date): "
-	Write-Verbose "$(Get-Date): "
+	Write-Verbose "$(Get-Date -Format G): "
+	Write-Verbose "$(Get-Date -Format G): Script start         : $($Script:StartTime)"
+	Write-Verbose "$(Get-Date -Format G): "
+	Write-Verbose "$(Get-Date -Format G): "
 }
 
 Function AbortScript
@@ -3343,7 +3334,7 @@ Function AbortScript
 		If(Test-Path variable:script:word)
 		{
 			$Script:Word.quit()
-			Write-Verbose "$(Get-Date): System Cleanup"
+			Write-Verbose "$(Get-Date -Format G): System Cleanup"
 			[System.Runtime.Interopservices.Marshal]::ReleaseComObject($Script:Word) | Out-Null
 			Remove-Variable -Name word -Scope Script 4>$Null
 		}
@@ -3357,13 +3348,13 @@ Function AbortScript
 		$wordprocess = (Get-Process 'WinWord' -ea 0) | Where-Object {$_.SessionId -eq $SessionID}
 		If($null -ne $wordprocess -and $wordprocess.Id -gt 0)
 		{
-			Write-Verbose "$(Get-Date): WinWord process is still running. Attempting to stop WinWord process # $($wordprocess.Id)"
+			Write-Verbose "$(Get-Date -Format G): WinWord process is still running. Attempting to stop WinWord process # $($wordprocess.Id)"
 			Stop-Process $wordprocess.Id -EA 0
 		}
 	}
 	[gc]::collect() 
 	[gc]::WaitForPendingFinalizers()
-	Write-Verbose "$(Get-Date): Script has been aborted"
+	Write-Verbose "$(Get-Date -Format G): Script has been aborted"
 	Exit
 }
 
@@ -3373,7 +3364,7 @@ Function AbortScript
 Function SendEmail
 {
 	Param([array]$Attachments)
-	Write-Verbose "$(Get-Date): Prepare to email"
+	Write-Verbose "$(Get-Date -Format G): Prepare to email"
 
 	$emailAttachment = $Attachments
 	$emailSubject = $Script:Title
@@ -3413,13 +3404,13 @@ $Script:Title is attached.
 		
 		If($?)
 		{
-			Write-Verbose "$(Get-Date): Email successfully sent using anonymous credentials"
+			Write-Verbose "$(Get-Date -Format G): Email successfully sent using anonymous credentials"
 		}
 		ElseIf(!$?)
 		{
 			$e = $error[0]
 
-			Write-Verbose "$(Get-Date): Email was not sent:"
+			Write-Verbose "$(Get-Date -Format G): Email was not sent:"
 			Write-Warning "$(Get-Date): Exception: $e.Exception" 
 		}
 	}
@@ -3427,7 +3418,7 @@ $Script:Title is attached.
 	{
 		If($UseSSL)
 		{
-			Write-Verbose "$(Get-Date): Trying to send email using current user's credentials with SSL"
+			Write-Verbose "$(Get-Date -Format G): Trying to send email using current user's credentials with SSL"
 			Send-MailMessage -Attachments $emailAttachment -Body $emailBody -BodyAsHtml -From $From `
 			-Port $SmtpPort -SmtpServer $SmtpServer -Subject $emailSubject -To $To `
 			-UseSSL *>$Null
@@ -3447,7 +3438,7 @@ $Script:Title is attached.
 			If($null -ne $e.Exception -and $e.Exception.ToString().Contains("5.7"))
 			{
 				#The server response was: 5.7.xx SMTP; Client was not authenticated to send anonymous mail during MAIL FROM
-				Write-Verbose "$(Get-Date): Current user's credentials failed. Ask for usable credentials."
+				Write-Verbose "$(Get-Date -Format G): Current user's credentials failed. Ask for usable credentials."
 
 				If($Dev)
 				{
@@ -3473,19 +3464,19 @@ $Script:Title is attached.
 
 				If($?)
 				{
-					Write-Verbose "$(Get-Date): Email successfully sent using new credentials"
+					Write-Verbose "$(Get-Date -Format G): Email successfully sent using new credentials"
 				}
 				ElseIf(!$?)
 				{
 					$e = $error[0]
 
-					Write-Verbose "$(Get-Date): Email was not sent:"
+					Write-Verbose "$(Get-Date -Format G): Email was not sent:"
 					Write-Warning "$(Get-Date): Exception: $e.Exception" 
 				}
 			}
 			Else
 			{
-				Write-Verbose "$(Get-Date): Email was not sent:"
+				Write-Verbose "$(Get-Date -Format G): Email was not sent:"
 				Write-Warning "$(Get-Date): Exception: $e.Exception" 
 			}
 		}
@@ -3507,13 +3498,19 @@ Function ProcessScriptSetup
 		The PSAdmin module could not be loaded.
 		`n`n
 		`t`t
+		Are you running this script against a V17 RAS server?
+		`n`n
+		`t`t
 		Please see the Prerequisites section in the ReadMe file (RAS_Inventory_V1_ReadMe.rtf).
+		`n`n
+		`t`t
+		https://carlwebster.sharefile.com/d-safd2a2d3b45f401f8b9678f2a1730f42
 		`n`n
 		`t`t
 		Script cannot continue.
 		`n`n
 		"
-		Write-Verbose "$(Get-Date): "
+		Write-Verbose "$(Get-Date -Format G): "
 		AbortScript
 	}
 
@@ -3521,7 +3518,7 @@ Function ProcessScriptSetup
 	If($Script:ServerName -eq "localhost")
 	{
 		$Script:ServerName = $env:ComputerName
-		Write-Verbose "$(Get-Date): Server name has been changed from localhost to $($Script:ServerName)"
+		Write-Verbose "$(Get-Date -Format G): Server name has been changed from localhost to $($Script:ServerName)"
 	}
 	
 	#if computer name is an IP address, get host name from DNS
@@ -3535,7 +3532,7 @@ Function ProcessScriptSetup
 		If($? -and $Null -ne $Result)
 		{
 			$Script:ServerName = $Result.HostName
-			Write-Verbose "$(Get-Date): Server name has been changed from $ip to $Script:ServerName"
+			Write-Verbose "$(Get-Date -Format G): Server name has been changed from $ip to $Script:ServerName"
 		}
 		Else
 		{
@@ -3551,14 +3548,14 @@ Function ProcessScriptSetup
 	{
 		#get server name
 		#first test to make sure the server is reachable
-		Write-Verbose "$(Get-Date): Testing to see if $Script:ServerName is online and reachable"
+		Write-Verbose "$(Get-Date -Format G): Testing to see if $Script:ServerName is online and reachable"
 		If(Test-Connection -ComputerName $Script:ServerName -quiet -EA 0)
 		{
-			Write-Verbose "$(Get-Date): Server $Script:ServerName is online."
+			Write-Verbose "$(Get-Date -Format G): Server $Script:ServerName is online."
 		}
 		Else
 		{
-			Write-Verbose "$(Get-Date): Server $Script:ServerName is offline"
+			Write-Verbose "$(Get-Date -Format G): Server $Script:ServerName is offline"
 			$ErrorActionPreference = $SaveEAPreference
 			Write-Error "
 			`n`n
@@ -3577,7 +3574,7 @@ Function ProcessScriptSetup
 	
 	$creds = Get-Credential -UserName $Script:User -message "Enter credentials to connect to $Script:ServerName"
 
-	Write-Verbose "$(Get-Date): Attempting connection to $Script:ServerName as $($creds.UserName)"
+	Write-Verbose "$(Get-Date -Format G): Attempting connection to $Script:ServerName as $($creds.UserName)"
 	$PSDefaultParameterValues = @{"*:Verbose"=$False}
 	
 	$Results = New-RASSession -username $creds.UserName -Password $creds.Password -Server $Script:ServerName -EA 0 *>$Null
@@ -3603,10 +3600,10 @@ Function ProcessScriptSetup
 	{
 		$PSDefaultParameterValues = @{"*:Verbose"=$True}
 		$Script:User = $creds.UserName
-		Write-Verbose "$(Get-Date): Successfully connected to $Script:ServerName as $Script:User"
+		Write-Verbose "$(Get-Date -Format G): Successfully connected to $Script:ServerName as $Script:User"
 	}
 
-	Write-Verbose "$(Get-Date): Get RAS Version"
+	Write-Verbose "$(Get-Date -Format G): Get RAS Version"
 	$Results = Get-RASVersion -EA 0 4>$Null
 	
 	If($? -and $Null -ne $Results)
@@ -3617,7 +3614,7 @@ Function ProcessScriptSetup
 	{
 		$Script:RASVersion = 0
 	}
-	Write-Verbose "$(Get-Date): Running RAS Version $($Script:RASVersion)"
+	Write-Verbose "$(Get-Date -Format G): Running RAS Version $($Script:RASVersion)"
 	$Script:Title = "Parallels RAS Inventory"
 }
 #endregion
@@ -3625,12 +3622,12 @@ Function ProcessScriptSetup
 #region script end
 Function ProcessScriptEnd
 {
-	Write-Verbose "$(Get-Date): Script has completed"
-	Write-Verbose "$(Get-Date): "
+	Write-Verbose "$(Get-Date -Format G): Script has completed"
+	Write-Verbose "$(Get-Date -Format G): "
 
 	#http://poshtips.com/measuring-elapsed-time-in-powershell/
-	Write-Verbose "$(Get-Date): Script started: $($Script:StartTime)"
-	Write-Verbose "$(Get-Date): Script ended: $(Get-Date)"
+	Write-Verbose "$(Get-Date -Format G): Script started: $($Script:StartTime)"
+	Write-Verbose "$(Get-Date -Format G): Script ended: $(Get-Date)"
 	$runtime = $(Get-Date) - $Script:StartTime
 	$Str = [string]::format("{0} days, {1} hours, {2} minutes, {3}.{4} seconds",
 		$runtime.Days,
@@ -3638,7 +3635,7 @@ Function ProcessScriptEnd
 		$runtime.Minutes,
 		$runtime.Seconds,
 		$runtime.Milliseconds)
-	Write-Verbose "$(Get-Date): Elapsed time: $($Str)"
+	Write-Verbose "$(Get-Date -Format G): Elapsed time: $($Str)"
 
 	If($Dev)
 	{
@@ -3730,11 +3727,11 @@ Function ProcessScriptEnd
 			try 
 			{
 				Stop-Transcript | Out-Null
-				Write-Verbose "$(Get-Date): $Script:LogPath is ready for use"
+				Write-Verbose "$(Get-Date -Format G): $Script:LogPath is ready for use"
 			} 
 			catch 
 			{
-				Write-Verbose "$(Get-Date): Transcript/log stop failed"
+				Write-Verbose "$(Get-Date -Format G): Transcript/log stop failed"
 			}
 		}
 	}
@@ -3756,7 +3753,7 @@ Function ProcessScriptEnd
 #region process farm
 Function ProcessFarm
 {
-	Write-Verbose "$(Get-Date): Processing Farm"
+	Write-Verbose "$(Get-Date -Format G): Processing Farm"
 	
 	$Results = Get-RASFarmSettings -EA 0
 
@@ -3799,7 +3796,7 @@ Function ProcessFarm
 
 Function OutputFarm
 {
-	Write-Verbose "$(Get-Date): `tOutput Farm"
+	Write-Verbose "$(Get-Date -Format G): `tOutput Farm"
 	
 	If($MSWord -or $PDF)
 	{
@@ -3818,7 +3815,7 @@ Function OutputFarm
 
 Function ProcessFarmSites
 {
-	Write-Verbose "$(Get-Date): `tProcessing Farm Sites"
+	Write-Verbose "$(Get-Date -Format G): `tProcessing Farm Sites"
 	$Sites = Get-Site -EA 0 4> $Null
 
 	If(!$?)
@@ -3876,7 +3873,7 @@ Function OutputFarmSite
 {
 	Param([object]$Site)
 	
-	Write-Verbose "$(Get-Date): `t`tOutput Farm Site $($Site.Name)"
+	Write-Verbose "$(Get-Date -Format G): `t`tOutput Farm Site $($Site.Name)"
 	$SiteSettings = Get-SiteStatus -Siteid $Site.Id -EA 0 4> $Null
 	
 	If(!$?)
@@ -3905,7 +3902,7 @@ Function OutputFarmSite
 			WriteHTMLLine 0 0 "Unable to retrieve Site Status for Site $Site.Name"
 		}
 	}
-	ElseIf($? -and $Null -eq $Sites)
+	ElseIf($? -and $Null -eq $SiteSettings)
 	{
 		Write-Warning "
 		`n`n
@@ -3981,6 +3978,7 @@ Function OutputFarmSite
 		-Format $wdTableGrid `
 		-AutoFit $wdAutoFitFixed;
 
+		SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 		SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 		$Table.Columns.Item(1).Width = 200;
@@ -4021,7 +4019,7 @@ Function OutputFarmSite
 
 Function ProcessSites
 {
-	Write-Verbose "$(Get-Date): `tProcessing Sites"
+	Write-Verbose "$(Get-Date -Format G): `tProcessing Sites"
 	$Sites = Get-Site -EA 0 4> $Null
 
 	If(!$?)
@@ -4159,7 +4157,7 @@ Function OutputSite
 {
 	Param([object]$Site)
 	
-	Write-Verbose "$(Get-Date): `tOutput Site $($Site.Name)"
+	Write-Verbose "$(Get-Date -Format G): `tOutput Site $($Site.Name)"
 	$RDSHosts = Get-RDS -Siteid $Site.Id -EA 0 4> $Null
 	
 	If(!$?)
@@ -4183,7 +4181,7 @@ Function OutputSite
 			WriteHTMLLine 0 0 "Unable to retrieve RD Session Hosts for Site $($Site.Name)"
 		}
 	}
-	ElseIf($? -and $Null -eq $Sites)
+	ElseIf($? -and $Null -eq $RDSHosts)
 	{
 		Write-Warning "
 		`n`n
@@ -4223,7 +4221,7 @@ Function OutputSite
 			WriteHTMLLine 2 0 "RD Session Hosts"
 		}
 
-		Write-Verbose "$(Get-Date): `t`tOutput Site RD Session Hosts"
+		Write-Verbose "$(Get-Date -Format G): `t`tOutput Site RD Session Hosts"
 		ForEach($RDSHost in $RDSHosts)
 		{
 			$RDSStatus = Get-RDSStatus -Id $RDSHost.Id -EA 0 4>$Null
@@ -4293,6 +4291,7 @@ Function OutputSite
 					-Format $wdTableGrid `
 					-AutoFit $wdAutoFitFixed;
 
+					SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 					SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 					$Table.Columns.Item(1).Width = 200;
@@ -4364,7 +4363,7 @@ Function OutputSite
 			WriteHTMLLine 0 0 "Unable to retrieve VDI for Site $($Site.Name)"
 		}
 	}
-	ElseIf($? -and $Null -eq $Sites)
+	ElseIf($? -and $Null -eq $VDIHosts)
 	{
 		Write-Warning "
 		`n`n
@@ -4400,7 +4399,7 @@ Function OutputSite
 			WriteHTMLLine 2 0 "VDI Providers"
 		}
 
-		Write-Verbose "$(Get-Date): `t`tOutput Site VDI Providers"
+		Write-Verbose "$(Get-Date -Format G): `t`tOutput Site VDI Providers"
 		ForEach($VDIHost in $VDIHosts)
 		{
 			$VDIHostStatus = Get-VDIHostStatus -Id $VDIHost.Id -EA 0 4>$Null
@@ -4468,6 +4467,7 @@ Function OutputSite
 					-Format $wdTableGrid `
 					-AutoFit $wdAutoFitFixed;
 
+					SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 					SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 					$Table.Columns.Item(1).Width = 200;
@@ -4537,7 +4537,7 @@ Function OutputSite
 			WriteHTMLLine 0 0 "Unable to retrieve Gateways for Site $($Site.Name)"
 		}
 	}
-	ElseIf($? -and $Null -eq $Sites)
+	ElseIf($? -and $Null -eq $GWs)
 	{
 		Write-Warning "
 		`n`n
@@ -4573,7 +4573,7 @@ Function OutputSite
 			WriteHTMLLine 2 0 "Gateways"
 		}
 
-		Write-Verbose "$(Get-Date): `t`tOutput Site Gateways"
+		Write-Verbose "$(Get-Date -Format G): `t`tOutput Site Gateways"
 		ForEach($GW in $GWs)
 		{
 			$GWStatus = Get-GWStatus -Id $GW.Id -EA 0 4>$Null
@@ -4643,6 +4643,7 @@ Function OutputSite
 					-Format $wdTableGrid `
 					-AutoFit $wdAutoFitFixed;
 
+					SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 					SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 					$Table.Columns.Item(1).Width = 200;
@@ -4714,7 +4715,7 @@ Function OutputSite
 			WriteHTMLLine 0 0 "Unable to retrieve Publishing Agents for Site $($Site.Name)"
 		}
 	}
-	ElseIf($? -and $Null -eq $Sites)
+	ElseIf($? -and $Null -eq $PAs)
 	{
 		Write-Warning "
 		`n`n
@@ -4750,7 +4751,7 @@ Function OutputSite
 			WriteHTMLLine 2 0 "Publishing Agents"
 		}
 
-		Write-Verbose "$(Get-Date): `t`tOutput Site Publishing Agents"
+		Write-Verbose "$(Get-Date -Format G): `t`tOutput Site Publishing Agents"
 		ForEach($PA in $PAs)
 		{
 			$PAStatus = Get-PAStatus -Id $PA.Id -EA 0 4>$Null
@@ -4775,7 +4776,7 @@ Function OutputSite
 					WriteHTMLLine 0 0 "Unable to retrieve Publishing Agents Status for Publishing Agents $($PA.Id)"
 				}
 			}
-			ElseIf($? -and $Null -eq $GWStatus)
+			ElseIf($? -and $Null -eq $PAStatus)
 			{
 				Write-Warning "
 				`n`n
@@ -4816,6 +4817,7 @@ Function OutputSite
 					-Format $wdTableGrid `
 					-AutoFit $wdAutoFitFixed;
 
+					SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 					SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 					$Table.Columns.Item(1).Width = 200;
@@ -4860,7 +4862,7 @@ Function OutputSite
 		}
 	}
 	
-	Write-Verbose "$(Get-Date): `t`tOutput Site RD Session Hosts for Site $($Site.Name)"
+	Write-Verbose "$(Get-Date -Format G): `t`tOutput Site RD Session Hosts for Site $($Site.Name)"
 	$RDSHosts = Get-RDS -Siteid $Site.Id -EA 0 4> $Null
 	
 	If(!$?)
@@ -4884,7 +4886,7 @@ Function OutputSite
 			WriteHTMLLine 0 0 "Unable to retrieve RD Session Hosts for Site $($Site.Name)"
 		}
 	}
-	ElseIf($? -and $Null -eq $Sites)
+	ElseIf($? -and $Null -eq $RDSHosts)
 	{
 		Write-Warning "
 		`n`n
@@ -4922,7 +4924,7 @@ Function OutputSite
 
 		ForEach($RDSHost in $RDSHosts)
 		{
-			Write-Verbose "$(Get-Date): `t`t`tOutput Site RD Session Host $($RDSHost.Server)"
+			Write-Verbose "$(Get-Date -Format G): `t`t`tOutput Site RD Session Host $($RDSHost.Server)"
 			$RDSStatus = Get-RDSStatus -Id $RDSHost.Id -EA 0 4>$Null
 			
 			If(!$?)
@@ -5050,6 +5052,7 @@ Function OutputSite
 					-Format $wdTableGrid `
 					-AutoFit $wdAutoFitFixed;
 
+					SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 					SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 					$Table.Columns.Item(1).Width = 200;
@@ -5125,6 +5128,7 @@ Function OutputSite
 				-Format $wdTableGrid `
 				-AutoFit $wdAutoFitFixed;
 
+				SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 				SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 				$Table.Columns.Item(1).Width = 200;
@@ -5466,6 +5470,7 @@ Function OutputSite
 				-Format $wdTableGrid `
 				-AutoFit $wdAutoFitFixed;
 
+				SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 				SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 				$Table.Columns.Item(1).Width = 200;
@@ -5630,6 +5635,7 @@ Function OutputSite
 				-Format $wdTableGrid `
 				-AutoFit $wdAutoFitFixed;
 
+				SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 				SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 				$Table.Columns.Item(1).Width = 200;
@@ -5789,6 +5795,7 @@ Function OutputSite
 				-Format $wdTableGrid `
 				-AutoFit $wdAutoFitFixed;
 
+				SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 				SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 				$Table.Columns.Item(1).Width = 200;
@@ -5952,6 +5959,7 @@ Function OutputSite
 				-Format $wdTableGrid `
 				-AutoFit $wdAutoFitFixed;
 
+				SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 				SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 				$Table.Columns.Item(1).Width = 200;
@@ -5985,7 +5993,7 @@ Function OutputSite
 		}
 	}
 
-	Write-Verbose "$(Get-Date): `t`tOutput Site RD Session Host Groups for Site $($Site.Name)"
+	Write-Verbose "$(Get-Date -Format G): `t`tOutput Site RD Session Host Groups for Site $($Site.Name)"
 	$RDSGroups = Get-RDSGroup -Siteid $Site.Id -EA 0 4> $Null
 	
 	If(!$?)
@@ -6009,7 +6017,7 @@ Function OutputSite
 			WriteHTMLLine 0 0 "Unable to retrieve RD Session Host Groups for Site $($Site.Name)"
 		}
 	}
-	ElseIf($? -and $Null -eq $Sites)
+	ElseIf($? -and $Null -eq $RDSGroups)
 	{
 		Write-Warning "
 		`n`n
@@ -6047,7 +6055,7 @@ Function OutputSite
 
 		ForEach($RDSGroup in $RDSGroups)
 		{
-			Write-Verbose "$(Get-Date): `t`t`tOutput Site RD Session Host Group $($RDSGroup.Name)"
+			Write-Verbose "$(Get-Date -Format G): `t`t`tOutput Site RD Session Host Group $($RDSGroup.Name)"
 			If($MSWord -or $PDF)
 			{
 				WriteWordLine 3 0 "Group $($RDSGroup.Name)"
@@ -6063,6 +6071,7 @@ Function OutputSite
 				-Format $wdTableGrid `
 				-AutoFit $wdAutoFitFixed;
 
+				SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 				SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 				$Table.Columns.Item(1).Width = 200;
@@ -6148,6 +6157,7 @@ Function OutputSite
 				-Format $wdTableGrid `
 				-AutoFit $wdAutoFitFixed;
 
+				SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 				SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 				$Table.Columns.Item(1).Width = 200;
@@ -6402,6 +6412,7 @@ Function OutputSite
 				-Format $wdTableGrid `
 				-AutoFit $wdAutoFitFixed;
 
+				SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 				SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 				$Table.Columns.Item(1).Width = 200;
@@ -6527,6 +6538,7 @@ Function OutputSite
 				-Format $wdTableGrid `
 				-AutoFit $wdAutoFitFixed;
 
+				SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 				SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 				$Table.Columns.Item(1).Width = 200;
@@ -6647,6 +6659,7 @@ Function OutputSite
 				-Format $wdTableGrid `
 				-AutoFit $wdAutoFitFixed;
 
+				SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 				SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 				$Table.Columns.Item(1).Width = 200;
@@ -6773,6 +6786,7 @@ Function OutputSite
 				-Format $wdTableGrid `
 				-AutoFit $wdAutoFitFixed;
 
+				SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 				SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 				$Table.Columns.Item(1).Width = 200;
@@ -6806,7 +6820,7 @@ Function OutputSite
 		}
 	}
 
-	Write-Verbose "$(Get-Date): `t`tOutput Site RD Session Host Scheduler for Site $($Site.Name)"
+	Write-Verbose "$(Get-Date -Format G): `t`tOutput Site RD Session Host Scheduler for Site $($Site.Name)"
 	$RDSSchedules = Get-RDSSchedule -Siteid $Site.Id -EA 0 4> $Null
 	
 	If(!$?)
@@ -6830,7 +6844,7 @@ Function OutputSite
 			WriteHTMLLine 0 0 "Unable to retrieve RD Session Host Scheduler for Site $($Site.Name)"
 		}
 	}
-	ElseIf($? -and $Null -eq $Sites)
+	ElseIf($? -and $Null -eq $RDSSchedules)
 	{
 		Write-Warning "
 		`n`n
@@ -6868,7 +6882,7 @@ Function OutputSite
 
 		ForEach($RDSSchedule in $RDSSchedules)
 		{
-			Write-Verbose "$(Get-Date): `t`t`tOutput Site RD Session Host Scheduler $($RDSSchedule.Name)"
+			Write-Verbose "$(Get-Date -Format G): `t`t`tOutput Site RD Session Host Scheduler $($RDSSchedule.Name)"
 			$Action = $RDSSchedule.Action
 			If($RDSSChedule.Action -eq "Reboot")
 			{
@@ -7022,6 +7036,7 @@ Function OutputSite
 				-Format $wdTableGrid `
 				-AutoFit $wdAutoFitFixed;
 
+				SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 				SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 				$Table.Columns.Item(1).Width = 200;
@@ -7141,6 +7156,7 @@ Function OutputSite
 				-Format $wdTableGrid `
 				-AutoFit $wdAutoFitFixed;
 
+				SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 				SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 				$Table.Columns.Item(1).Width = 200;
@@ -7238,6 +7254,7 @@ Function OutputSite
 				-Format $wdTableGrid `
 				-AutoFit $wdAutoFitFixed;
 
+				SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 				SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 				$Table.Columns.Item(1).Width = 200;
@@ -7350,6 +7367,7 @@ Function OutputSite
 				-Format $wdTableGrid `
 				-AutoFit $wdAutoFitFixed;
 
+				SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 				SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 				$Table.Columns.Item(1).Width = 200;
@@ -7481,7 +7499,7 @@ Function OutputSite
 			WriteHTMLLine 0 0 "Unable to retrieve VDI for Site $($Site.Name)"
 		}
 	}
-	ElseIf($? -and $Null -eq $Sites)
+	ElseIf($? -and $Null -eq $VDIHosts)
 	{
 		Write-Warning "
 		`n`n
@@ -7517,7 +7535,7 @@ Function OutputSite
 			WriteHTMLLine 2 0 "VDI"
 		}
 
-		Write-Verbose "$(Get-Date): `t`tOutput Site VDI"
+		Write-Verbose "$(Get-Date -Format G): `t`tOutput Site VDI"
 		ForEach($VDIHost in $VDIHosts)
 		{
 			$VDIHostStatus = Get-VDIHostStatus -Id $VDIHost.Id -EA 0 4>$Null
@@ -7598,6 +7616,7 @@ Function OutputSite
 					-Format $wdTableGrid `
 					-AutoFit $wdAutoFitFixed;
 
+					SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 					SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 					$Table.Columns.Item(1).Width = 200;
@@ -7695,6 +7714,7 @@ Function OutputSite
 				-Format $wdTableGrid `
 				-AutoFit $wdAutoFitFixed;
 
+				SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 				SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 				$Table.Columns.Item(1).Width = 200;
@@ -7766,6 +7786,7 @@ Function OutputSite
 				-Format $wdTableGrid `
 				-AutoFit $wdAutoFitFixed;
 
+				SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 				SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 				$Table.Columns.Item(1).Width = 200;
@@ -7824,6 +7845,7 @@ Function OutputSite
 				-Format $wdTableGrid `
 				-AutoFit $wdAutoFitFixed;
 
+				SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 				SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 				$Table.Columns.Item(1).Width = 200;
@@ -7898,6 +7920,7 @@ Function OutputSite
 				-Format $wdTableGrid `
 				-AutoFit $wdAutoFitFixed;
 
+				SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 				SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 				$Table.Columns.Item(1).Width = 200;
@@ -7998,6 +8021,7 @@ Function OutputSite
 					-Format $wdTableGrid `
 					-AutoFit $wdAutoFitFixed;
 
+					SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 					SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 					$Table.Columns.Item(1).Width = 200;
@@ -8206,6 +8230,7 @@ Function OutputSite
 					-Format $wdTableGrid `
 					-AutoFit $wdAutoFitFixed;
 
+					SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 					SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 					$Table.Columns.Item(1).Width = 200;
@@ -8290,6 +8315,7 @@ Function OutputSite
 					-Format $wdTableGrid `
 					-AutoFit $wdAutoFitFixed;
 
+					SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 					SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 					$Table.Columns.Item(1).Width = 200;
@@ -8355,6 +8381,7 @@ Function OutputSite
 					-Format $wdTableGrid `
 					-AutoFit $wdAutoFitFixed;
 
+					SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 					SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 					$Table.Columns.Item(1).Width = 200;
@@ -8418,6 +8445,7 @@ Function OutputSite
 					-Format $wdTableGrid `
 					-AutoFit $wdAutoFitFixed;
 
+					SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 					SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 					$Table.Columns.Item(1).Width = 200;
@@ -8499,6 +8527,7 @@ Function OutputSite
 					-Format $wdTableGrid `
 					-AutoFit $wdAutoFitFixed;
 
+					SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 					SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 					$Table.Columns.Item(1).Width = 200;
@@ -8622,7 +8651,7 @@ Function OutputSite
 			WriteHTMLLine 0 0 "Unable to retrieve Gateways for Site $($Site.Name)"
 		}
 	}
-	ElseIf($? -and $Null -eq $Sites)
+	ElseIf($? -and $Null -eq $GWs)
 	{
 		Write-Warning "
 		`n`n
@@ -8658,7 +8687,7 @@ Function OutputSite
 			WriteHTMLLine 2 0 "Gateways"
 		}
 
-		Write-Verbose "$(Get-Date): `t`tOutput Gateways"
+		Write-Verbose "$(Get-Date -Format G): `t`tOutput Gateways"
 		ForEach($GW in $GWs)
 		{
 			$GWStatus = Get-GWStatus -Id $GW.Id -EA 0 4>$Null
@@ -8844,6 +8873,7 @@ Function OutputSite
 					-Format $wdTableGrid `
 					-AutoFit $wdAutoFitFixed;
 
+					SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 					SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 					$Table.Columns.Item(1).Width = 200;
@@ -8994,6 +9024,7 @@ Function OutputSite
 				-Format $wdTableGrid `
 				-AutoFit $wdAutoFitFixed;
 
+				SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 				SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 				$Table.Columns.Item(1).Width = 200;
@@ -9223,6 +9254,7 @@ Function OutputSite
 				-Format $wdTableGrid `
 				-AutoFit $wdAutoFitFixed;
 
+				SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 				SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 				$Table.Columns.Item(1).Width = 200;
@@ -9425,6 +9457,7 @@ Function OutputSite
 				-Format $wdTableGrid `
 				-AutoFit $wdAutoFitFixed;
 
+				SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 				SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 				$Table.Columns.Item(1).Width = 200;
@@ -9517,6 +9550,7 @@ Function OutputSite
 				-Format $wdTableGrid `
 				-AutoFit $wdAutoFitFixed;
 
+				SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 				SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 				$Table.Columns.Item(1).Width = 200;
@@ -9705,6 +9739,7 @@ Function OutputSite
 				-Format $wdTableGrid `
 				-AutoFit $wdAutoFitFixed;
 
+				SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 				SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 				$Table.Columns.Item(1).Width = 200;
@@ -9831,6 +9866,7 @@ Function OutputSite
 				-Format $wdTableGrid `
 				-AutoFit $wdAutoFitFixed;
 
+				SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 				SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 				$Table.Columns.Item(1).Width = 200;
@@ -9967,6 +10003,7 @@ Function OutputSite
 				-Format $wdTableGrid `
 				-AutoFit $wdAutoFitFixed;
 
+				SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 				SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 				$Table.Columns.Item(1).Width = 200;
@@ -10092,6 +10129,7 @@ Function OutputSite
 				-Format $wdTableGrid `
 				-AutoFit $wdAutoFitFixed;
 
+				SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 				SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 				$Table.Columns.Item(1).Width = 200;
@@ -10148,7 +10186,7 @@ Function OutputSite
 			WriteHTMLLine 0 0 "Unable to retrieve Publishing Agents for Site $($Site.Name)"
 		}
 	}
-	ElseIf($? -and $Null -eq $Sites)
+	ElseIf($? -and $Null -eq $PAs)
 	{
 		Write-Warning "
 		`n`n
@@ -10184,7 +10222,7 @@ Function OutputSite
 			WriteHTMLLine 2 0 "Publishing Agents"
 		}
 
-		Write-Verbose "$(Get-Date): `t`tOutput Publishing Agents"
+		Write-Verbose "$(Get-Date -Format G): `t`tOutput Publishing Agents"
 		ForEach($PA in $PAs)
 		{
 			$PAStatus = Get-PAStatus -Id $PA.Id -EA 0 4>$Null
@@ -10210,7 +10248,7 @@ Function OutputSite
 					WriteHTMLLine 0 0 "Unable to retrieve Publishing Agent Status for Publishing Agent $($PA.Id)"
 				}
 			}
-			ElseIf($? -and $Null -eq $GWStatus)
+			ElseIf($? -and $Null -eq $PAStatus)
 			{
 				Write-Warning "
 				`n`n
@@ -10262,6 +10300,7 @@ Function OutputSite
 					-Format $wdTableGrid `
 					-AutoFit $wdAutoFitFixed;
 
+					SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 					SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 					$Table.Columns.Item(1).Width = 200;
@@ -10337,6 +10376,7 @@ Function OutputSite
 				-Format $wdTableGrid `
 				-AutoFit $wdAutoFitFixed;
 
+				SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 				SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 				$Table.Columns.Item(1).Width = 200;
@@ -10407,7 +10447,7 @@ Function OutputSite
 			WriteHTMLLine 0 0 "Unable to retrieve Certificates for Site $($Site.Name)"
 		}
 	}
-	ElseIf($? -and $Null -eq $Sites)
+	ElseIf($? -and $Null -eq $Certs)
 	{
 		Write-Warning "
 		`n`n
@@ -10443,7 +10483,7 @@ Function OutputSite
 			WriteHTMLLine 2 0 "Certificates"
 		}
 
-		Write-Verbose "$(Get-Date): `t`tOutput Certificates"
+		Write-Verbose "$(Get-Date -Format G): `t`tOutput Certificates"
 		ForEach($Cert in $Certs)
 		{
 			If($MSWord -or $PDF)
@@ -10463,6 +10503,7 @@ Function OutputSite
 				-Format $wdTableGrid `
 				-AutoFit $wdAutoFitFixed;
 
+				SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 				SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 				$Table.Columns.Item(1).Width = 200;
@@ -10542,6 +10583,7 @@ Function OutputSite
 				-Format $wdTableGrid `
 				-AutoFit $wdAutoFitFixed;
 
+				SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 				SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 				$Table.Columns.Item(1).Width = 200;
@@ -10611,7 +10653,7 @@ Function OutputSite
 			WriteHTMLLine 0 0 "Unable to retrieve Certificates for Site $($Site.Name)"
 		}
 	}
-	ElseIf($? -and $Null -eq $Sites)
+	ElseIf($? -and $Null -eq $FarmSettings)
 	{
 		Write-Warning "
 		`n`n
@@ -10648,7 +10690,7 @@ Function OutputSite
 			WriteHTMLLine 2 0 "Settings"
 		}
 
-		Write-Verbose "$(Get-Date): `t`tOutput Settings"
+		Write-Verbose "$(Get-Date -Format G): `t`tOutput Settings"
 	}
 		
 	If($MSWord -or $PDF)
@@ -10677,6 +10719,7 @@ Function OutputSite
 		-Format $wdTableGrid `
 		-AutoFit $wdAutoFitFixed;
 
+		SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 		SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 		$Table.Columns.Item(1).Width = 200;
@@ -10780,6 +10823,7 @@ Function OutputSite
 		-Format $wdTableGrid `
 		-AutoFit $wdAutoFitFixed;
 
+		SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 		SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 		$Table.Columns.Item(1).Width = 200;
@@ -10856,11 +10900,11 @@ Function OutputSite
 #region process load balancing
 Function ProcessLoadBalancing
 {
-	Write-Verbose "$(Get-Date): Processing Load balancing"
+	Write-Verbose "$(Get-Date -Format G): Processing Load balancing"
 	
 	OutputLoadBalancingSectionPage
 	
-	Write-Verbose "$(Get-Date): `tProcessing Load balancing"
+	Write-Verbose "$(Get-Date -Format G): `tProcessing Load balancing"
 	
 	$results = Get-RASLBSettings -EA 0 4>$Null
 	
@@ -10933,7 +10977,7 @@ Function OutputRASLBSettings
 {
 	Param([object] $RASLBSettings)
 	
-	Write-Verbose "$(Get-Date): `t`tOutput Load balancing"
+	Write-Verbose "$(Get-Date -Format G): `t`tOutput Load balancing"
 	
 	If($MSWord -or $PDF)
 	{
@@ -10978,6 +11022,7 @@ Function OutputRASLBSettings
 		-Format $wdTableGrid `
 		-AutoFit $wdAutoFitFixed;
 
+		SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 		SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 		$Table.Columns.Item(1).Width = 275;
@@ -11058,7 +11103,7 @@ Function ListFolder($folder, $spaces)
 
 Function ProcessPublishing
 {
-	Write-Verbose "$(Get-Date): Processing Publishing"
+	Write-Verbose "$(Get-Date -Format G): Processing Publishing"
 	
 	$Sites = Get-Site -EA 0 4> $Null
 
@@ -11110,7 +11155,7 @@ Function ProcessPublishing
 		{
 			OutputPublishingSectionPage $Site.Name
 			
-			Write-Verbose "$(Get-Date): `tProcessing Publishing for Site $($Site.Name)"
+			Write-Verbose "$(Get-Date -Format G): `tProcessing Publishing for Site $($Site.Name)"
 			
 			$results = Get-PubItem -SiteId $Site.Id -EA 0 4>$Null
 				
@@ -11190,7 +11235,7 @@ Function OutputPublishingSettings
 {
 	Param([object] $PubItems, [uint32] $SiteId, [string] $xSiteName)
 	
-	Write-Verbose "$(Get-Date): `t`tOutput Publishing for Site $xSiteName"
+	Write-Verbose "$(Get-Date -Format G): `t`tOutput Publishing for Site $xSiteName"
 	
 	<#
 	Folder
@@ -11203,7 +11248,7 @@ Function OutputPublishingSettings
 	#>
 
 	#Get the published items default settings
-	Write-Verbose "$(Get-Date): `t`t`tRetrieve Publishing Default Site Settings for Site $xSiteName"
+	Write-Verbose "$(Get-Date -Format G): `t`t`tRetrieve Publishing Default Site Settings for Site $xSiteName"
 	$results = Get-PubDefaultSettings -SiteId $SiteId -EA 0 4>$Null
 	
 	If(!$?)
@@ -11318,7 +11363,7 @@ Function OutputPublishingSettings
 	
 	ForEach($PubItem in $PubItems)
 	{
-		Write-Verbose "$(Get-Date): `t`t`t`tOutput $($PubItem.Name)"
+		Write-Verbose "$(Get-Date -Format G): `t`t`t`tOutput $($PubItem.Name)"
 
 		If(ValidObject $PubItem WinType)
 		{
@@ -11517,6 +11562,7 @@ Function OutputPublishingSettings
 				-Format $wdTableGrid `
 				-AutoFit $wdAutoFitFixed;
 
+				SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 				SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 				$Table.Columns.Item(1).Width = 200;
@@ -11553,6 +11599,7 @@ Function OutputPublishingSettings
 				-Format $wdTableGrid `
 				-AutoFit $wdAutoFitFixed;
 
+				SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 				SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 				$Table.Columns.Item(1).Width = 200;
@@ -11576,6 +11623,7 @@ Function OutputPublishingSettings
 				-Format $wdTableGrid `
 				-AutoFit $wdAutoFitFixed;
 
+				SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 				SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 				$Table.Columns.Item(1).Width = 200;
@@ -12160,6 +12208,7 @@ Function OutputPublishingSettings
 				-Format $wdTableGrid `
 				-AutoFit $wdAutoFitFixed;
 
+				SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 				SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 				$Table.Columns.Item(1).Width = 200;
@@ -12196,6 +12245,7 @@ Function OutputPublishingSettings
 				-Format $wdTableGrid `
 				-AutoFit $wdAutoFitFixed;
 
+				SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 				SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 				$Table.Columns.Item(1).Width = 200;
@@ -12220,6 +12270,7 @@ Function OutputPublishingSettings
 				-Format $wdTableGrid `
 				-AutoFit $wdAutoFitFixed;
 
+				SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 				SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 				$Table.Columns.Item(1).Width = 200;
@@ -12243,6 +12294,7 @@ Function OutputPublishingSettings
 				-Format $wdTableGrid `
 				-AutoFit $wdAutoFitFixed;
 
+				SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 				SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 				$Table.Columns.Item(1).Width = 200;
@@ -13047,6 +13099,7 @@ Function OutputPublishingSettings
 				-Format $wdTableGrid `
 				-AutoFit $wdAutoFitFixed;
 
+				SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 				SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 				$Table.Columns.Item(1).Width = 200;
@@ -13083,6 +13136,7 @@ Function OutputPublishingSettings
 				-Format $wdTableGrid `
 				-AutoFit $wdAutoFitFixed;
 
+				SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 				SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 				$Table.Columns.Item(1).Width = 200;
@@ -13145,6 +13199,7 @@ Function OutputPublishingSettings
 				-Format $wdTableGrid `
 				-AutoFit $wdAutoFitFixed;
 
+				SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 				SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 				$Table.Columns.Item(1).Width = 200;
@@ -13170,6 +13225,7 @@ Function OutputPublishingSettings
 				-Format $wdTableGrid `
 				-AutoFit $wdAutoFitFixed;
 
+				SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 				SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 				$Table.Columns.Item(1).Width = 200;
@@ -13194,6 +13250,7 @@ Function OutputPublishingSettings
 				-Format $wdTableGrid `
 				-AutoFit $wdAutoFitFixed;
 
+				SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 				SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 				$Table.Columns.Item(1).Width = 200;
@@ -13239,6 +13296,7 @@ Function OutputPublishingSettings
 				-Format $wdTableGrid `
 				-AutoFit $wdAutoFitFixed;
 
+				SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 				SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 				$Table.Columns.Item(1).Width = 200;
@@ -13297,6 +13355,7 @@ Function OutputPublishingSettings
 				-Format $wdTableGrid `
 				-AutoFit $wdAutoFitFixed;
 
+				SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 				SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 				$Table.Columns.Item(1).Width = 200;
@@ -13355,6 +13414,7 @@ Function OutputPublishingSettings
 				-Format $wdTableGrid `
 				-AutoFit $wdAutoFitFixed;
 
+				SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 				SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 				$Table.Columns.Item(1).Width = 200;
@@ -13738,6 +13798,34 @@ Function OutputPublishingSettings
 				Else
 				{
 					Line 3 "Settings are not replicated to all Sites"
+				}
+				Line 0 ""
+
+				Line 2 "License"
+				Line 3 "Inherit default settings`t`t`t`t: " $PubItem.InheritLicenseDefaultSettings.ToString()
+
+				If($PubItem.InheritLicenseDefaultSettings)
+				{
+					Line 3 "Session Sharing`t`t`t`t`t`t: " $DefaultDisableSessionSharing
+					Line 3 "Allow users to start only 1 instance of this application: " $DefaultOneInstancePerUser.ToString()
+					Line 3 "Concurrent licenses`t`t`t`t`t: " $DefaultConCurrentLicenses
+					Line 3 "If limit is exceeded`t`t`t`t`t: " $DefaultLicenseLimitNotify
+				}
+				Else
+				{
+					Line 3 "Session Sharing`t`t`t`t`t`t: " $SessionSharing
+					Line 3 "Allow users to start only 1 instance of this application: " $PubItem.OneInstancePerUser.ToString()
+					Line 3 "Concurrent licenses`t`t`t`t`t: " $ConCurrentLicenses
+					Line 3 "If limit is exceeded`t`t`t`t`t: " $LicenseLimitNotify
+				}
+
+				If($PubItem.InheritLicenseDefaultSettings)
+				{
+					Line 3 "Settings are replicated to all Sites`t`t`t: " $DefaultReplicateLicenseSettings.ToString()
+				}
+				Else
+				{
+					Line 3 "Settings are replicated to all Sites`t`t`t: " $PubItem.ReplicateLicenseSettings.ToString()
 				}
 				Line 0 ""
 
@@ -14181,6 +14269,52 @@ Function OutputPublishingSettings
 				}
 				WriteHTMLLine 0 0 ""
 
+				WriteHTMLLine 3 0 "License"
+				$rowdata = @()
+				$columnHeaders = @("Inherit default settings",($Script:htmlsb),$PubItem.InheritLicenseDefaultSettings.ToString(),$htmlwhite)
+
+				If($PubItem.InheritLicenseDefaultSettings)
+				{
+					$rowdata += @(,("Session Sharing",($Script:htmlsb),$DefaultDisableSessionSharing,$htmlwhite))
+					If($DefaultOneInstancePerUser)
+					{
+						$rowdata += @(,("Allow users to start only 1 instance of this application",($Script:htmlsb),"True",$htmlwhite))
+					}
+					Else
+					{
+						$rowdata += @(,("Allow users to start only 1 instance of this application",($Script:htmlsb),"False",$htmlwhite))
+					}
+					$rowdata += @(,("Concurrent licenses",($Script:htmlsb),$DefaultConCurrentLicenses,$htmlwhite))
+					$rowdata += @(,("If limit is exceeded",($Script:htmlsb),$DefaultLicenseLimitNotify,$htmlwhite))
+				}
+				Else
+				{
+					$rowdata += @(,("Session Sharing",($Script:htmlsb),$SessionSharing,$htmlwhite))
+					If($PubItem.OneInstancePerUser)
+					{
+						$rowdata += @(,("Allow users to start only 1 instance of this application",($Script:htmlsb),"True",$htmlwhite))
+					}
+					Else
+					{
+						$rowdata += @(,("Allow users to start only 1 instance of this application",($Script:htmlsb),"False",$htmlwhite))
+					}
+					$rowdata += @(,("Concurrent licenses",($Script:htmlsb),$ConCurrentLicenses,$htmlwhite))
+					$rowdata += @(,("If limit is exceeded",($Script:htmlsb),$LicenseLimitNotify,$htmlwhite))
+				}
+				If($PubItem.InheritLicenseDefaultSettings)
+				{
+					$rowdata += @(,("Settings are replicated to all Sites: ",($Script:htmlsb),$DefaultReplicateLicenseSettings.ToString(),$htmlwhite))
+				}
+				Else
+				{
+					$rowdata += @(,("Settings are replicated to all Sites: ",($Script:htmlsb),$PubItem.ReplicateLicenseSettings.ToString(),$htmlwhite))
+				}
+
+				$msg = ""
+				$columnWidths = @("200","300")
+				FormatHTMLTable $msg "auto" -rowArray $rowdata -columnArray $columnHeaders -fixedWidth $columnWidths
+				WriteHTMLLine 0 0 ""
+
 				WriteHTMLLine 3 0 "Display"
 				$rowdata = @()
 				$columnHeaders = @("Inherit default settings",($Script:htmlsb),$PubItem.InheritDisplayDefaultSettings.ToString(),$htmlwhite)
@@ -14423,6 +14557,7 @@ Function OutputPublishingSettings
 				-Format $wdTableGrid `
 				-AutoFit $wdAutoFitFixed;
 
+				SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 				SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 				$Table.Columns.Item(1).Width = 200;
@@ -14459,6 +14594,7 @@ Function OutputPublishingSettings
 				-Format $wdTableGrid `
 				-AutoFit $wdAutoFitFixed;
 
+				SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 				SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 				$Table.Columns.Item(1).Width = 200;
@@ -14487,6 +14623,7 @@ Function OutputPublishingSettings
 				-Format $wdTableGrid `
 				-AutoFit $wdAutoFitFixed;
 
+				SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 				SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 				$Table.Columns.Item(1).Width = 200;
@@ -15224,6 +15361,7 @@ Function OutputPublishingSettings
 				-Format $wdTableGrid `
 				-AutoFit $wdAutoFitFixed;
 
+				SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 				SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 				$Table.Columns.Item(1).Width = 200;
@@ -15260,6 +15398,7 @@ Function OutputPublishingSettings
 				-Format $wdTableGrid `
 				-AutoFit $wdAutoFitFixed;
 
+				SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 				SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 				$Table.Columns.Item(1).Width = 200;
@@ -15288,6 +15427,7 @@ Function OutputPublishingSettings
 				-Format $wdTableGrid `
 				-AutoFit $wdAutoFitFixed;
 
+				SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 				SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 				$Table.Columns.Item(1).Width = 200;
@@ -15311,6 +15451,7 @@ Function OutputPublishingSettings
 				-Format $wdTableGrid `
 				-AutoFit $wdAutoFitFixed;
 
+				SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 				SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 				$Table.Columns.Item(1).Width = 200;
@@ -16103,6 +16244,7 @@ Function OutputPublishingSettings
 				-Format $wdTableGrid `
 				-AutoFit $wdAutoFitFixed;
 
+				SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 				SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 				$Table.Columns.Item(1).Width = 200;
@@ -16139,6 +16281,7 @@ Function OutputPublishingSettings
 				-Format $wdTableGrid `
 				-AutoFit $wdAutoFitFixed;
 
+				SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 				SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 				$Table.Columns.Item(1).Width = 200;
@@ -16202,6 +16345,7 @@ Function OutputPublishingSettings
 				-Format $wdTableGrid `
 				-AutoFit $wdAutoFitFixed;
 
+				SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 				SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 				$Table.Columns.Item(1).Width = 200;
@@ -16227,6 +16371,7 @@ Function OutputPublishingSettings
 				-Format $wdTableGrid `
 				-AutoFit $wdAutoFitFixed;
 
+				SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 				SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 				$Table.Columns.Item(1).Width = 200;
@@ -16249,6 +16394,7 @@ Function OutputPublishingSettings
 				-Format $wdTableGrid `
 				-AutoFit $wdAutoFitFixed;
 
+				SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 				SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 				$Table.Columns.Item(1).Width = 200;
@@ -17114,6 +17260,7 @@ Function OutputPublishingSettings
 				-Format $wdTableGrid `
 				-AutoFit $wdAutoFitFixed;
 
+				SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 				SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 				$Table.Columns.Item(1).Width = 200;
@@ -17150,6 +17297,7 @@ Function OutputPublishingSettings
 				-Format $wdTableGrid `
 				-AutoFit $wdAutoFitFixed;
 
+				SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 				SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 				$Table.Columns.Item(1).Width = 200;
@@ -17175,6 +17323,7 @@ Function OutputPublishingSettings
 				-Format $wdTableGrid `
 				-AutoFit $wdAutoFitFixed;
 
+				SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 				SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 				$Table.Columns.Item(1).Width = 200;
@@ -17212,6 +17361,7 @@ Function OutputPublishingSettings
 				-Format $wdTableGrid `
 				-AutoFit $wdAutoFitFixed;
 
+				SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 				SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 				$Table.Columns.Item(1).Width = 200;
@@ -18813,6 +18963,7 @@ Function OutputPubItemShortCuts
 			-Format $wdTableGrid `
 			-AutoFit $wdAutoFitContent;
 
+			SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 			SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 			$Table.Rows.SetLeftIndent($Indent0TabStops,$wdAdjustProportional)
@@ -18845,6 +18996,7 @@ Function OutputPubItemShortCuts
 			-Format $wdTableGrid `
 			-AutoFit $wdAutoFitContent;
 
+			SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 			SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 			$Table.Rows.SetLeftIndent($Indent0TabStops,$wdAdjustProportional)
@@ -18964,11 +19116,11 @@ Function OutputPubItemShortCuts
 #region process universal printing
 Function ProcessUniversalPrinting
 {
-	Write-Verbose "$(Get-Date): Processing Universal Printing"
+	Write-Verbose "$(Get-Date -Format G): Processing Universal Printing"
 	
 	OutputUniversalPrintingSectionPage
 	
-	Write-Verbose "$(Get-Date): `tProcessing Universal Printing"
+	Write-Verbose "$(Get-Date -Format G): `tProcessing Universal Printing"
 	
 	$results = Get-RASPrintingSettings -EA 0 4>$Null
 	
@@ -19178,7 +19330,7 @@ Function OutputUniversalPrintingSettings
 {
 	Param([object]$Printingobj, [object]$RDSobj, [object]$VDIHostsobj)
  
-	Write-Verbose "$(Get-Date): `t`tOutput Universal printing"
+	Write-Verbose "$(Get-Date -Format G): `t`tOutput Universal printing"
 	
 	If($MSWord -or $PDF)
 	{
@@ -19219,6 +19371,7 @@ Function OutputUniversalPrintingSettings
 		-Format $wdTableGrid `
 		-AutoFit $wdAutoFitFixed;
 
+		SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 		SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 		$Table.Columns.Item(1).Width = 200;
@@ -19394,7 +19547,7 @@ Function OutputUniversalPrinterDriversSettings
 {
 	Param([object] $RASPrinterSettings)
  
-	Write-Verbose "$(Get-Date): `t`tOutput Printer drivers"
+	Write-Verbose "$(Get-Date -Format G): `t`tOutput Printer drivers"
 	
 	If($MSWord -or $PDF)
 	{
@@ -19434,6 +19587,7 @@ Function OutputUniversalPrinterDriversSettings
 			-Format $wdTableGrid `
 			-AutoFit $wdAutoFitFixed;
 
+			SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 			SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 			$Table.Columns.Item(1).Width = 100;
@@ -19479,6 +19633,7 @@ Function OutputUniversalPrinterDriversSettings
 			-Format $wdTableGrid `
 			-AutoFit $wdAutoFitFixed;
 
+			SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 			SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 			$Table.Columns.Item(1).Width = 100;
@@ -19564,7 +19719,7 @@ Function OutputUniversalPrinterFontsSettings
 {
 	Param([object] $RASFontsSettings)
 
-	Write-Verbose "$(Get-Date): `t`tOutput Fonts management"
+	Write-Verbose "$(Get-Date -Format G): `t`tOutput Fonts management"
 	
 	If($MSWord -or $PDF)
 	{
@@ -19594,6 +19749,7 @@ Function OutputUniversalPrinterFontsSettings
 		-Format $wdTableGrid `
 		-AutoFit $wdAutoFitFixed;
 
+		SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 		SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 		$Table.Columns.Item(1).Width = 100;
@@ -19738,6 +19894,7 @@ Function OutputUniversalPrinterFontsSettings
 		-Format $wdTableGrid `
 		-AutoFit $wdAutoFitFixed;
 
+		SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 		SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 		$Table.Columns.Item(1).Width = 125;
@@ -19813,11 +19970,11 @@ Function OutputUniversalPrinterFontsSettings
 #region process universal scanning
 Function ProcessUniversalScanning
 {
-	Write-Verbose "$(Get-Date): Processing Universal scanning"
+	Write-Verbose "$(Get-Date -Format G): Processing Universal scanning"
 	
 	OutputUniversalScanningSectionPage
 	
-	Write-Verbose "$(Get-Date): `tProcessing Universal Scanning"
+	Write-Verbose "$(Get-Date -Format G): `tProcessing Universal Scanning"
 	
 	$results = Get-RASScanningSettings -EA 0 4>$Null
 	
@@ -19984,7 +20141,7 @@ Function OutputUniversalScanningSettings
 {
  Param([object]$WIAobj, [object]$TWAINobj, [object]$RDSobj, [object]$VDIHostsobj)
  
-	Write-Verbose "$(Get-Date): `t`tOutput WIA"
+	Write-Verbose "$(Get-Date -Format G): `t`tOutput WIA"
 	
 	If($MSWord -or $PDF)
 	{
@@ -20024,6 +20181,7 @@ Function OutputUniversalScanningSettings
 		-Format $wdTableGrid `
 		-AutoFit $wdAutoFitFixed;
 
+		SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 		SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 		$Table.Columns.Item(1).Width = 100;
@@ -20186,7 +20344,7 @@ Function OutputUniversalScanningSettings
 		WriteHTMLLine 0 0 ""
 	}
 
-	Write-Verbose "$(Get-Date): `t`tOutput TWAIN"
+	Write-Verbose "$(Get-Date -Format G): `t`tOutput TWAIN"
 	
 	If($MSWord -or $PDF)
 	{
@@ -20226,6 +20384,7 @@ Function OutputUniversalScanningSettings
 		-Format $wdTableGrid `
 		-AutoFit $wdAutoFitFixed;
 
+		SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 		SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 		$Table.Columns.Item(1).Width = 100;
@@ -20390,11 +20549,11 @@ Function OutputUniversalScanningSettings
 #region process connection
 Function ProcessConnection
 {
-	Write-Verbose "$(Get-Date): Processing Connection"
+	Write-Verbose "$(Get-Date -Format G): Processing Connection"
 	
 	OutputConnectionSectionPage
 	
-	Write-Verbose "$(Get-Date): `tProcessing Authentication"
+	Write-Verbose "$(Get-Date -Format G): `tProcessing Authentication"
 	
 	$results = Get-RASAuthSettings -EA 0 4>$Null
 	
@@ -20445,7 +20604,7 @@ Function ProcessConnection
 		OutputRASAuthSettings $results
 	}
 
-	Write-Verbose "$(Get-Date): `tProcessing Settings"
+	Write-Verbose "$(Get-Date -Format G): `tProcessing Settings"
 	
 	$results = Get-RASSessionSetting -EA 0 4>$Null
 	
@@ -20496,7 +20655,7 @@ Function ProcessConnection
 		OutputRASSessionSetting $results
 	}
 
-	Write-Verbose "$(Get-Date): `tProcessing Second level authentication"
+	Write-Verbose "$(Get-Date -Format G): `tProcessing Second level authentication"
 	
 	$results = Get-2FASetting -EA 0 4>$Null
 	
@@ -20547,7 +20706,7 @@ Function ProcessConnection
 		Output2FASetting $results
 	}
 
-	Write-Verbose "$(Get-Date): `tProcessing Allowed devices"
+	Write-Verbose "$(Get-Date -Format G): `tProcessing Allowed devices"
 	
 	$results = Get-RASAllowedDevicesSetting -EA 0 4>$Null
 	
@@ -20620,7 +20779,7 @@ Function OutputRASAuthSettings
 {
 	Param([object] $RASAuthSettings)
 	
-	Write-Verbose "$(Get-Date): `t`tOutput Authentication"
+	Write-Verbose "$(Get-Date -Format G): `t`tOutput Authentication"
 	
 	If($MSWord -or $PDF)
 	{
@@ -20665,6 +20824,7 @@ Function OutputRASAuthSettings
 		-Format $wdTableGrid `
 		-AutoFit $wdAutoFitFixed;
 
+		SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 		SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 		$Table.Columns.Item(1).Width = 275;
@@ -20719,7 +20879,7 @@ Function OutputRASSessionSetting
 {
 	Param([object] $RASSessionSettings)
 	
-	Write-Verbose "$(Get-Date): `t`tOutput Settings"
+	Write-Verbose "$(Get-Date -Format G): `t`tOutput Settings"
 	
 	If($MSWord -or $PDF)
 	{
@@ -20794,6 +20954,7 @@ Function OutputRASSessionSetting
 		-Format $wdTableGrid `
 		-AutoFit $wdAutoFitFixed;
 
+		SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 		SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 		$Table.Columns.Item(1).Width = 275;
@@ -20834,7 +20995,7 @@ Function Output2FASetting
 {
 	Param([object] $RAS2FASettings)
 	
-	Write-Verbose "$(Get-Date): `t`tOutput Second level authentication"
+	Write-Verbose "$(Get-Date -Format G): `t`tOutput Second level authentication"
 	
 	If($MSWord -or $PDF)
 	{
@@ -20939,6 +21100,7 @@ Function Output2FASetting
 			-Format $wdTableGrid `
 			-AutoFit $wdAutoFitFixed;
 
+			SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 			SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 			$Table.Columns.Item(1).Width = 275;
@@ -21042,6 +21204,7 @@ Function Output2FASetting
 			-Format $wdTableGrid `
 			-AutoFit $wdAutoFitFixed;
 
+			SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 			SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 			$Table.Columns.Item(1).Width = 275;
@@ -21063,6 +21226,7 @@ Function Output2FASetting
 		-Format $wdTableGrid `
 		-AutoFit $wdAutoFitFixed;
 
+		SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 		SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 		$Table.Columns.Item(1).Width = 275;
@@ -21416,7 +21580,7 @@ Function OutputRASAllowedDevicesSetting
 {
 	Param([object] $RASAllowedDevices)
 	
-	Write-Verbose "$(Get-Date): `t`tOutput Allowed devices"
+	Write-Verbose "$(Get-Date -Format G): `t`tOutput Allowed devices"
 	
 	Switch ($RASAllowedDevices.AllowClientMode)
 	{
@@ -21541,6 +21705,7 @@ Function OutputRASAllowedDevicesSetting
 		-Format $wdTableGrid `
 		-AutoFit $wdAutoFitFixed;
 
+		SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 		SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 		$Table.Columns.Item(1).Width = 200;
@@ -21621,11 +21786,11 @@ Function OutputRASAllowedDevicesSetting
 #region process administration
 Function ProcessAdministration
 {
-	Write-Verbose "$(Get-Date): Processing Administration"
+	Write-Verbose "$(Get-Date -Format G): Processing Administration"
 	
 	OutputAdministrationSectionPage
 	
-	Write-Verbose "$(Get-Date): `tProcessing Accounts"
+	Write-Verbose "$(Get-Date -Format G): `tProcessing Accounts"
 	
 	$results = Get-RASAdminAccount -EA 0 4>$Null
 	
@@ -21678,7 +21843,7 @@ Function ProcessAdministration
 		OutputRASAccounts $results
 	}
 
-	Write-Verbose "$(Get-Date): `tProcessing Features"
+	Write-Verbose "$(Get-Date -Format G): `tProcessing Features"
 	
 	$RASFeatures = Get-RASSystemSettings -EA 0 4>$Null
 	
@@ -21949,7 +22114,7 @@ Function OutputRASAccounts
 {
 	Param([object] $RASAccounts)
 	
-	Write-Verbose "$(Get-Date): `t`tOutput Accounts"
+	Write-Verbose "$(Get-Date -Format G): `t`tOutput Accounts"
 	
 	If($MSWord -or $PDF)
 	{
@@ -21990,6 +22155,7 @@ Function OutputRASAccounts
 			-Format $wdTableGrid `
 			-AutoFit $wdAutoFitFixed;
 
+			SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 			SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 			$Table.Columns.Item(1).Width = 180;
@@ -22033,7 +22199,7 @@ Function OutputRASFeatures
 {
 	Param([object] $RASFeatures)
 	
-	Write-Verbose "$(Get-Date): `t`tOutput Features"
+	Write-Verbose "$(Get-Date -Format G): `t`tOutput Features"
 	
 	If($MSWord -or $PDF)
 	{
@@ -22063,6 +22229,7 @@ Function OutputRASFeatures
 		-Format $wdTableGrid `
 		-AutoFit $wdAutoFitFixed;
 
+		SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 		SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 		$Table.Columns.Item(1).Width = 180;
@@ -22121,6 +22288,7 @@ Function OutputRASTurbo
 		-Format $wdTableGrid `
 		-AutoFit $wdAutoFitFixed;
 
+		SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 		SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 		$Table.Columns.Item(1).Width = 180;
@@ -22153,7 +22321,7 @@ Function OutputRASSettings
 {
 	Param([object] $RASFeatures)
 	
-	Write-Verbose "$(Get-Date): `t`tOutput Settings"
+	Write-Verbose "$(Get-Date -Format G): `t`tOutput Settings"
 	
 	If($MSWord -or $PDF)
 	{
@@ -22182,6 +22350,7 @@ Function OutputRASSettings
 		-Format $wdTableGrid `
 		-AutoFit $wdAutoFitFixed;
 
+		SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 		SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 		$Table.Columns.Item(1).Width = 180;
@@ -22235,6 +22404,7 @@ Function OutputRASSettings
 			-Format $wdTableGrid `
 			-AutoFit $wdAutoFitFixed;
 
+			SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 			SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 			$Table.Columns.Item(1).Width = 180;
@@ -22261,6 +22431,7 @@ Function OutputRASSettings
 			-Format $wdTableGrid `
 			-AutoFit $wdAutoFitFixed;
 
+			SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 			SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 			$Table.Columns.Item(1).Width = 180;
@@ -22355,6 +22526,7 @@ Function OutputRASSettings
 		-Format $wdTableGrid `
 		-AutoFit $wdAutoFitFixed;
 
+		SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 		SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 		$Table.Columns.Item(1).Width = 180;
@@ -22387,7 +22559,7 @@ Function OutputRASMailboxSettings
 {
 	Param([object] $RASMailboxSettings)
 	
-	Write-Verbose "$(Get-Date): `t`tOutput Mailbox"
+	Write-Verbose "$(Get-Date -Format G): `t`tOutput Mailbox"
 	
 	If($MSWord -or $PDF)
 	{
@@ -22430,6 +22602,7 @@ Function OutputRASMailboxSettings
 		-Format $wdTableGrid `
 		-AutoFit $wdAutoFitFixed;
 
+		SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 		SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 		$Table.Columns.Item(1).Width = 180;
@@ -22493,6 +22666,7 @@ Function OutputRASMailboxSettings
 		-Format $wdTableGrid `
 		-AutoFit $wdAutoFitFixed;
 
+		SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 		SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 		$Table.Columns.Item(1).Width = 180;
@@ -22526,7 +22700,7 @@ Function OutputRASNotifications
 {
 	Param([object] $RASNotificationHandlers)
 	
-	Write-Verbose "$(Get-Date): `t`tOutput Notifications"
+	Write-Verbose "$(Get-Date -Format G): `t`tOutput Notifications"
 	
 	If($MSWord -or $PDF)
 	{
@@ -22662,6 +22836,7 @@ Function OutputRASNotifications
 			-Format $wdTableGrid `
 			-AutoFit $wdAutoFitFixed;
 
+			SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 			SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 			$Table.Columns.Item(1).Width = 180;
@@ -22841,6 +23016,7 @@ Function OutputRASNotificationScripts
 			-Format $wdTableGrid `
 			-AutoFit $wdAutoFitFixed;
 
+			SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 			SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 			$Table.Columns.Item(1).Width = 180;
@@ -22882,7 +23058,7 @@ Function OutputRASNotificationScripts
 #region process licensing
 Function ProcessLicensing
 {
-	Write-Verbose "$(Get-Date): Processing Licensing"
+	Write-Verbose "$(Get-Date -Format G): Processing Licensing"
 
 	$results = Get-LicenseDetails -EA 0 4>$Null
 	
@@ -22938,7 +23114,7 @@ Function OutputRASLicense
 {
 	Param([object] $RASLicense)
 	
-	Write-Verbose "$(Get-Date): `tOutput RAS License"
+	Write-Verbose "$(Get-Date -Format G): `tOutput RAS License"
 
 	If($MSWord -or $PDF)
 	{
@@ -23000,6 +23176,7 @@ Function OutputRASLicense
 		-Format $wdTableGrid `
 		-AutoFit $wdAutoFitFixed;
 
+		SetWordCellFormat -Collection $Table -Size 10 -BackgroundColor $wdColorWhite
 		SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
 		$Table.Columns.Item(1).Width = 180;
@@ -23123,7 +23300,7 @@ ProcessLicensing
 #endregion
 
 #region finish script
-Write-Verbose "$(Get-Date): Finishing up document"
+Write-Verbose "$(Get-Date -Format G): Finishing up document"
 #end of document processing
 
 If(($MSWORD -or $PDF) -and ($Script:CoverPagesExist))

--- a/RAS_Inventory_V1_ReadMe.rtf
+++ b/RAS_Inventory_V1_ReadMe.rtf
@@ -49,72 +49,69 @@ Normal Table;}{\*\cs15 \additive \rtlch\fcs1 \ab\af0\afs32 \ltrch\fcs0 \b\fs32\k
 \sbasedon10 \sunhideused \styrsid11488686 Hyperlink;}{\s19\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\f43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 
 \snext19 \sqformat \spriority1 \styrsid10945524 No Spacing;}{\*\cs20 \additive \rtlch\fcs1 \af0 \ltrch\fcs0 \ul\cf19 \sbasedon10 \styrsid15355254 FollowedHyperlink;}{\*\cs21 \additive \rtlch\fcs1 \af0 \ltrch\fcs0 \cf15\chshdng0\chcfpat0\chcbpat20 
 \sbasedon10 \ssemihidden \sunhideused \styrsid15166704 Unresolved Mention;}}{\*\listtable{\list\listtemplateid645948268\listhybrid{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext
-\leveltemplateid67698703\'02\'00.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li720\lin720 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext
-\leveltemplateid67698713\'02\'01.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
-\leveltemplateid67698715\'02\'02.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-180\li2160\lin2160 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
-\leveltemplateid67698703\'02\'03.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li2880\lin2880 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
-\leveltemplateid67698713\'02\'04.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li3600\lin3600 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
-\leveltemplateid67698715\'02\'05.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-180\li4320\lin4320 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
-\leveltemplateid67698703\'02\'06.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li5040\lin5040 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
-\leveltemplateid67698713\'02\'07.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
-\leveltemplateid67698715\'02\'08.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 \fi-180\li6480\lin6480 }{\listname ;}\listid319386001}{\list\listtemplateid-1120360756\listhybrid{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0
-\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0\hres0\chhres0 \fi-360\li720\lin720 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1
-\levelspace360\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0\hres0\chhres0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext
-\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0\hres0\chhres0 \fi-360\li2160\lin2160 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext\leveltemplateid67698689
-\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0\hres0\chhres0 \fi-360\li2880\lin2880 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698691
-\'01o;}{\levelnumbers;}\f2\fbias0\hres0\chhres0 \fi-360\li3600\lin3600 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698693
-\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0\hres0\chhres0 \fi-360\li4320\lin4320 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698689
-\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0\hres0\chhres0 \fi-360\li5040\lin5040 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698691
-\'01o;}{\levelnumbers;}\f2\fbias0\hres0\chhres0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698693
-\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0\hres0\chhres0 \fi-360\li6480\lin6480 }{\listname ;}\listid1250626038}{\list\listtemplateid-393728524\listhybrid{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360
-\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0\hres0\chhres0 \fi-360\li720\lin720 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext
-\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0\hres0\chhres0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext\leveltemplateid67698693
-\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0\hres0\chhres0 \fi-360\li2160\lin2160 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}
-\f3\fbias0\hres0\chhres0 \fi-360\li2880\lin2880 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0\hres0\chhres0 
-\fi-360\li3600\lin3600 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0\hres0\chhres0 
-\fi-360\li4320\lin4320 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0\hres0\chhres0 
-\fi-360\li5040\lin5040 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0\hres0\chhres0 \fi-360\li5760\lin5760 }
-{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0\hres0\chhres0 \fi-360\li6480\lin6480 }{\listname 
-;}\listid1724937716}{\list\listtemplateid-154213762\listhybrid{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext\leveltemplateid67698703\'02\'00.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 
-\ltrch\fcs0 \fbias0\hres0\chhres0 \fi-360\li720\lin720 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext\leveltemplateid67698713\'02\'01.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 
-\hres0\chhres0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext\leveltemplateid67698715\'02\'02.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 
-\fi-180\li2160\lin2160 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext\leveltemplateid67698703\'02\'03.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 
-\fi-360\li2880\lin2880 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698713\'02\'04.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 
-\fi-360\li3600\lin3600 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698715\'02\'05.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 
-\fi-180\li4320\lin4320 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698703\'02\'06.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 
-\fi-360\li5040\lin5040 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698713\'02\'07.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 
-\fi-360\li5760\lin5760 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698715\'02\'08.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \hres0\chhres0 
+\leveltemplateid67698703\'02\'00.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li720\lin720 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext\leveltemplateid67698713
+\'02\'01.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698715
+\'02\'02.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-180\li2160\lin2160 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698703
+\'02\'03.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li2880\lin2880 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698713
+\'02\'04.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li3600\lin3600 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698715
+\'02\'05.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-180\li4320\lin4320 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698703
+\'02\'06.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li5040\lin5040 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698713
+\'02\'07.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698715
+\'02\'08.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-180\li6480\lin6480 }{\listname ;}\listid319386001}{\list\listtemplateid-1120360756\listhybrid{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360
+\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0 \fi-360\li720\lin720 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext\leveltemplateid67698691
+\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 
+\fi-360\li2160\lin2160 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0 \fi-360\li2880\lin2880 }{\listlevel\levelnfc23
+\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li3600\lin3600 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0
+\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li4320\lin4320 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1
+\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0 \fi-360\li5040\lin5040 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360
+\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
+\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li6480\lin6480 }{\listname ;}\listid1250626038}{\list\listtemplateid-393728524\listhybrid{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1
+\levelspace360\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0 \fi-360\li720\lin720 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext
+\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}
+\f10\fbias0 \fi-360\li2160\lin2160 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0 \fi-360\li2880\lin2880 }{\listlevel
+\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li3600\lin3600 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0
+\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li4320\lin4320 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1
+\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0 \fi-360\li5040\lin5040 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360
+\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
+\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li6480\lin6480 }{\listname ;}\listid1724937716}{\list\listtemplateid-154213762\listhybrid{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0
+\levelindent0{\leveltext\leveltemplateid67698703\'02\'00.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fbias0 \fi-360\li720\lin720 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext
+\leveltemplateid67698713\'02\'01.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext\leveltemplateid67698715
+\'02\'02.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-180\li2160\lin2160 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext\leveltemplateid67698703\'02\'03.;}{\levelnumbers\'01;}
+\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li2880\lin2880 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698713\'02\'04.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 
+\ltrch\fcs0 \fi-360\li3600\lin3600 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698715\'02\'05.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 
+\fi-180\li4320\lin4320 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698703\'02\'06.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 
+\fi-360\li5040\lin5040 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698713\'02\'07.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 
+\fi-360\li5760\lin5760 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698715\'02\'08.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 
 \fi-180\li6480\lin6480 }{\listname ;}\listid1818835589}{\list\listtemplateid-183201164\listhybrid{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat0\levelspace0\levelindent0{\leveltext\leveltemplateid2071627316
-\'01\u-3913 ?;}{\levelnumbers;}\loch\af3\hich\af3\dbch\af31505\fbias0\hres0\chhres0 \fi-360\li720\lin720 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext\leveltemplateid67698691
-\'01o;}{\levelnumbers;}\f2\fbias0\hres0\chhres0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers
-;}\f10\fbias0\hres0\chhres0 \fi-360\li2160\lin2160 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}
-\f3\fbias0\hres0\chhres0 \fi-360\li2880\lin2880 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0\hres0\chhres0 
-\fi-360\li3600\lin3600 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0\hres0\chhres0 
-\fi-360\li4320\lin4320 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0\hres0\chhres0 
-\fi-360\li5040\lin5040 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0\hres0\chhres0 \fi-360\li5760\lin5760 }
-{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0\hres0\chhres0 \fi-360\li6480\lin6480 }{\listname 
-;}\listid1955283310}{\list\listtemplateid1049127720\listhybrid{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}
-\f3\fbias0\hres0\chhres0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0\hres0\chhres0 
-\fi-360\li2160\lin2160 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0\hres0\chhres0 
-\fi-360\li2880\lin2880 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0\hres0\chhres0 
-\fi-360\li3600\lin3600 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0\hres0\chhres0 \fi-360\li4320\lin4320 }
-{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0\hres0\chhres0 \fi-360\li5040\lin5040 }{\listlevel
-\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0\hres0\chhres0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc23
-\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0\hres0\chhres0 \fi-360\li6480\lin6480 }{\listlevel\levelnfc23\levelnfcn23\leveljc0
-\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0\hres0\chhres0 \fi-360\li7200\lin7200 }{\listname ;}\listid2008440808}}{\*\listoverridetable
-{\listoverride\listid1955283310\listoverridecount0\ls1}{\listoverride\listid1818835589\listoverridecount0\ls2}{\listoverride\listid319386001\listoverridecount0\ls3}{\listoverride\listid1724937716\listoverridecount0\ls4}{\listoverride\listid1818835589
-\listoverridecount9{\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}{\lfolevel
-\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}\ls5}{\listoverride\listid2008440808\listoverridecount0\ls6}
-{\listoverride\listid1250626038\listoverridecount0\ls7}}{\*\pgptbl {\pgp\ipgp0\itap0\li0\ri0\sb0\sa0}}{\*\rsidtbl \rsid407474\rsid667579\rsid741398\rsid854968\rsid880017\rsid1206655\rsid1520287\rsid2313532\rsid2454835\rsid2638156\rsid2710199\rsid2828497
-\rsid2974686\rsid3342358\rsid3477011\rsid3547319\rsid3830441\rsid4281248\rsid4467197\rsid4945864\rsid5117009\rsid5767175\rsid5849890\rsid6095241\rsid6508857\rsid6508924\rsid6626993\rsid7016631\rsid7363671\rsid7681868\rsid7695940\rsid8013811\rsid8284628
-\rsid8726130\rsid8793422\rsid9122125\rsid9138287\rsid9186981\rsid9243658\rsid9252303\rsid9512169\rsid9838801\rsid9915873\rsid10101060\rsid10111376\rsid10290913\rsid10374270\rsid10777656\rsid10945524\rsid11337799\rsid11370278\rsid11430143\rsid11488686
-\rsid11602030\rsid11885223\rsid12197314\rsid12343757\rsid12481227\rsid12848963\rsid12856395\rsid12916989\rsid13133162\rsid13434991\rsid13725463\rsid13858952\rsid13987238\rsid14566444\rsid14697282\rsid14893653\rsid15166704\rsid15355254\rsid16005803
-\rsid16190354\rsid16670594\rsid16740185}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Carl Webster}{\creatim\yr2014\mo1\dy27\hr9\min47}
-{\revtim\yr2020\mo8\dy4\hr9\min57}{\version48}{\edmins871}{\nofpages18}{\nofwords3939}{\nofchars22457}{\nofcharsws26344}{\vern5}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}
+\'01\u-3913 ?;}{\levelnumbers;}\loch\af3\hich\af3\dbch\af31505\fbias0 \fi-360\li720\lin720 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}
+\f2\fbias0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li2160\lin2160 }
+{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0 \fi-360\li2880\lin2880 }{\listlevel\levelnfc23\levelnfcn23
+\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li3600\lin3600 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0
+\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li4320\lin4320 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative
+\levelspace0\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0 \fi-360\li5040\lin5040 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext
+\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698693
+\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li6480\lin6480 }{\listname ;}\listid1955283310}{\list\listtemplateid1049127720\listhybrid{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0
+{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
+\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li2160\lin2160 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698693
+\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li2880\lin2880 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}
+\f3\fbias0 \fi-360\li3600\lin3600 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li4320\lin4320 }
+{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li5040\lin5040 }{\listlevel\levelnfc23
+\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0
+\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li6480\lin6480 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative
+\levelspace360\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li7200\lin7200 }{\listname ;}\listid2008440808}}{\*\listoverridetable{\listoverride\listid1955283310\listoverridecount0\ls1}
+{\listoverride\listid1818835589\listoverridecount0\ls2}{\listoverride\listid319386001\listoverridecount0\ls3}{\listoverride\listid1724937716\listoverridecount0\ls4}{\listoverride\listid1818835589\listoverridecount9{\lfolevel\listoverridestartat
+\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}{\lfolevel
+\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}\ls5}{\listoverride\listid2008440808\listoverridecount0\ls6}{\listoverride\listid1250626038\listoverridecount0\ls7}}{\*\pgptbl 
+{\pgp\ipgp0\itap0\li0\ri0\sb0\sa0}}{\*\rsidtbl \rsid407474\rsid667579\rsid741398\rsid854968\rsid880017\rsid1206655\rsid1520287\rsid2110091\rsid2313532\rsid2454835\rsid2638156\rsid2710199\rsid2828497\rsid2974686\rsid3342358\rsid3477011\rsid3547319
+\rsid3830441\rsid4281248\rsid4467197\rsid4546918\rsid4945864\rsid5117009\rsid5767175\rsid5849890\rsid6095241\rsid6508857\rsid6508924\rsid6626993\rsid7016631\rsid7363671\rsid7681868\rsid7695940\rsid8013811\rsid8284628\rsid8726130\rsid8793422\rsid9122125
+\rsid9138287\rsid9186981\rsid9243658\rsid9252303\rsid9512169\rsid9838801\rsid9899102\rsid9915873\rsid10101060\rsid10111376\rsid10290913\rsid10374270\rsid10777656\rsid10945524\rsid11337799\rsid11370278\rsid11430143\rsid11488686\rsid11602030\rsid11885223
+\rsid12197314\rsid12343757\rsid12481227\rsid12848963\rsid12856395\rsid12916989\rsid13133162\rsid13434991\rsid13725463\rsid13858952\rsid13897747\rsid13987238\rsid14566444\rsid14697282\rsid14893653\rsid15166704\rsid15355254\rsid15822428\rsid16005803
+\rsid16190354\rsid16670594\rsid16740185}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Webster}{\creatim\yr2014\mo1\dy27\hr9\min47}
+{\revtim\yr2021\mo4\dy20\hr7\min12}{\version53}{\edmins899}{\nofpages17}{\nofwords3928}{\nofchars22391}{\nofcharsws26267}{\vern23}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}
 \paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
 \widowctrl\ftnbj\aenddoc\trackmoves0\trackformatting1\donotembedsysfont0\relyonvml0\donotembedlingdata1\grfdocevents0\validatexml0\showplaceholdtext0\ignoremixedcontent0\saveinvalidxml0\showxmlerrors0\horzdoc\dghspace120\dgvspace120\dghorigin1701
-\dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale113\rsidroot11488686 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\docvar {__Grammarly_42____i}{H4sIAAAAAAAEAKtWckksSQxILCpxzi/NK1GyMqwFAAEhoTITAAAA}}
-{\*\docvar {__Grammarly_42___1}{H4sIAAAAAAAEAKtWcslP9kxRslIyNDY0NTMyNzQ1tzQxNzCxsDRW0lEKTi0uzszPAykwrwUApnIXnSwAAAA=}}\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\*\pnseclvl1\pnucrm\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl2
+\dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale111\rsidroot11488686 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\docvar {__Grammarly_42____i}{H4sIAAAAAAAEAKtWckksSQxILCpxzi/NK1GyMqwFAAEhoTITAAAA}}
+{\*\docvar {__Grammarly_42___1}{H4sIAAAAAAAEAKtWcslP9kxRslIyNDY0NTMyNzQ1tzQxNzCxsDRW0lEKTi0uzszPAykwNKwFABiP35stAAAA}}\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\*\pnseclvl1\pnucrm\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl2
 \pnucltr\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl3\pndec\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl4\pnlcltr\pnstart1\pnindent720\pnhang {\pntxta )}}{\*\pnseclvl5\pndec\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl6
 \pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl7\pnlcrm\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl8\pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl9\pnlcrm\pnstart1\pnindent720\pnhang 
 {\pntxtb (}{\pntxta )}}\pard\plain \ltrpar\s1\qc \li0\ri0\sb480\sl276\slmult1\keep\keepn\nowidctlpar\wrapdefault\faauto\outlinelevel0\rin0\lin0\itap0\pararsid11488686 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
@@ -150,7 +147,8 @@ NOTE: This script requires PowerShell V3 or later.
 \par }\pard\plain \ltrpar\s2\ql \li0\ri0\sb200\sl276\slmult1\keep\keepn\nowidctlpar\wrapdefault\faauto\outlinelevel1\rin0\lin0\itap0\pararsid10290913 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \ab\af43\afs26 \ltrch\fcs0 \b\fs26\cf22\insrsid10290913 \page \hich\af43\dbch\af31505\loch\f43 What the Script Documents
 \par }\pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid10290913 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af0\afs22 
-\ltrch\fcs0 \f31506\fs22\insrsid10290913\charrsid10290913 \hich\af31506\dbch\af31505\loch\f31506 The following items are documented:
+\ltrch\fcs0 \f31506\fs22\insrsid10290913\charrsid10290913 \hich\af31506\dbch\af31505\loch\f31506 The }{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid15822428 \hich\af31506\dbch\af31505\loch\f31506 script documents the }{\rtlch\fcs1 \af0\afs22 
+\ltrch\fcs0 \f31506\fs22\insrsid10290913\charrsid10290913 \hich\af31506\dbch\af31505\loch\f31506 following items:
 \par }{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid10290913 
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f3\fs22\insrsid2454835\charrsid5117009 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}}\pard \ltrpar\ql \fi-360\li720\ri0\nowidctlpar\wrapdefault\faauto\ls7\rin0\lin720\itap0\pararsid2454835 {
 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f31506\fs22\insrsid2454835\charrsid5117009 \hich\af31506\dbch\af31505\loch\f31506 Farm Settings}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f31506\fs22\insrsid10290913\charrsid5117009 
@@ -287,7 +285,7 @@ Auditing (Not implemented in PoSH yet)
 \ql \fi-360\li2160\ri0\nowidctlpar\wrapdefault\faauto\ls7\ilvl2\rin0\lin2160\itap0\pararsid10111376 {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f31506\fs22\insrsid10111376\charrsid5117009 \hich\af31506\dbch\af31505\loch\f31506 Information
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f10\fs22\insrsid10111376\charrsid5117009 \loch\af10\dbch\af31505\hich\f10 \'a7\tab}\hich\af31506\dbch\af31505\loch\f31506 Sites
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f10\fs22\insrsid10111376\charrsid5117009 \loch\af10\dbch\af31505\hich\f10 \'a7\tab}\hich\af31506\dbch\af31505\loch\f31506 Virtual Desktop
-\par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f10\fs22\insrsid10111376\charrsid5117009 \loch\af10\dbch\af31505\hich\f10 \'a7\tab}\hich\af31506\dbch\af31505\loch\f31506 Filtering
+\par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f10\fs22\insrsid10111376\charrsid5117009 \loch\af10\dbch\af31505\hich\f10 \'a7\tab}\hich\af31506\dbch\af31505\loch\f31506 Filterin\hich\af31506\dbch\af31505\loch\f31506 g
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f10\fs22\insrsid10111376\charrsid5117009 \loch\af10\dbch\af31505\hich\f10 \'a7\tab}\hich\af31506\dbch\af31505\loch\f31506 Shortcuts
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f2\fs22\insrsid10111376\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 o\tab}}\pard \ltrpar
 \ql \fi-360\li1440\ri0\nowidctlpar\wrapdefault\faauto\ls7\ilvl1\rin0\lin1440\itap0\pararsid10111376 {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f31506\fs22\insrsid10111376\charrsid5117009 \hich\af31506\dbch\af31505\loch\f31506 Type = PCApp
@@ -368,18 +366,21 @@ Before we can start using PowerShell to document any\hich\af37\dbch\af31505\loch
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 1.\tab}}\pard\plain \ltrpar\s17\ql \fi-360\li720\ri0\sa200\sl276\slmult1
 \nowidctlpar\wrapdefault\faauto\ls2\rin0\lin720\itap0\pararsid11488686\contextualspace \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af37\afs22 
 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 At least one Windows Server }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10777656 \hich\af37\dbch\af31505\loch\f37 running a fully configured }{\rtlch\fcs1 \af37\afs22 
-\ltrch\fcs0 \f37\fs22\insrsid7016631 \hich\af37\dbch\af31505\loch\f37 RAS}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 .
-\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid7016631\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 2.\tab}}\pard \ltrpar\s17\ql \fi-360\li720\ri0\sa200\sl276\slmult1
+\ltrch\fcs0 \f37\fs22\insrsid15822428 \hich\af37\dbch\af31505\loch\f37 Parallels }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid7016631 \hich\af37\dbch\af31505\loch\f37 RAS}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid15822428 
+\hich\af37\dbch\af31505\loch\f37  server}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 .
+\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid15822428 \hich\af37\dbch\af31505\loch\f37 2.\tab}}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid15822428 \hich\af37\dbch\af31505\loch\f37 
+Select the Server or Desktop \hich\af37\dbch\af31505\loch\f37 OS computer/VM for running this script.
+\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid7016631\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 3.\tab}}\pard \ltrpar\s17\ql \fi-360\li720\ri0\sa200\sl276\slmult1
 \nowidctlpar\wrapdefault\faauto\ls2\rin0\lin720\itap0\pararsid7016631\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid7016631\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 Install the }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid7016631 \hich\af37\dbch\af31505\loch\f37 RAS }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid7016631\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 PowerShell module.}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid7016631 
-\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid7016631 \hich\af37\dbch\af31505\loch\f37 3.\tab}\hich\af37\dbch\af31505\loch\f37 Download the RAS installer from }{\field{\*\fldinst {\rtlch\fcs1 \af37\afs22 
+\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid7016631 \hich\af37\dbch\af31505\loch\f37 4.\tab}\hich\af37\dbch\af31505\loch\f37 Download the RAS installer from }{\field{\*\fldinst {\rtlch\fcs1 \af37\afs22 
 \ltrch\fcs0 \f37\fs22\insrsid7016631 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid7016631\charrsid7016631 \hich\af37\dbch\af31505\loch\f37 https://www.parallels.com/products/ras/download/links/}{
 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid7016631 \hich\af37\dbch\af31505\loch\f37 " }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid1206655 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b86000000680074007400700073003a002f002f007700770077002e0070006100720061006c006c0065006c0073002e0063006f006d002f00700072006f00640075006300740073002f007200610073002f0064006f00
-77006e006c006f00610064002f006c0069006e006b0073002f000000795881f43b1d7f48af2c825dc485276300000000a5ab000300004100}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \cs18\f37\fs22\ul\cf2\insrsid7016631\charrsid16190354 \hich\af37\dbch\af31505\loch\f37 
-https://www.parallels.com/pro\hich\af37\dbch\af31505\loch\f37 ducts/ras/download/links/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid7016631 
-\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid7016631 \hich\af37\dbch\af31505\loch\f37 4.\tab}\hich\af37\dbch\af31505\loch\f37 There are two ways to install just the PowerShell module.
+77006e006c006f00610064002f006c0069006e006b0073002f000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000410000000000}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \cs18\f37\fs22\ul\cf2\insrsid7016631\charrsid16190354 
+\hich\af37\dbch\af31505\loch\f37 https://www.parallels.com/products/ras/download/links/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid7016631 
+\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid7016631 \hich\af37\dbch\af31505\loch\f37 5.\tab}\hich\af37\dbch\af31505\loch\f37 There are two ways to install just the PowerShell module.
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid9186981 \hich\af37\dbch\af31505\loch\f37 a.\tab}}\pard \ltrpar\s17\ql \fi-360\li1440\ri0\sa200\sl276\slmult1
 \nowidctlpar\wrapdefault\faauto\ls2\ilvl1\rin0\lin1440\itap0\pararsid9186981\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9186981 \hich\af37\dbch\af31505\loch\f37 
 Run RASInstaller-x.y.z.msi where x.y.z is the download's version number.
@@ -9749,7 +9750,7 @@ d68418de8418de8418de8c18d68418de8418de8418de8c18d68418de8418de8418de8c18d68418de
 d68418de8418de8418de8c18d68418de8418de8418de8c18d68418de8418de8418de8c18d68418de8418de8418de8c18d68418000000040000002701ffff030000000000}}}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9186981 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid9186981 \hich\af37\dbch\af31505\loch\f37 ii.\tab}}\pard \ltrpar\s17\ql \fi-180\li2160\ri0\sa200\sl276\slmult1
 \nowidctlpar\wrapdefault\faauto\ls2\ilvl2\rin0\lin2160\itap0\pararsid9138287\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9186981 \hich\af37\dbch\af31505\loch\f37 Deselect every option except }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
-\i\f37\fs22\insrsid9186981\charrsid9186981 \hich\af37\dbch\af31505\loch\f37 Parallels RAS PowerShell}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9186981 .
+\i\f37\fs22\insrsid9186981\charrsid9186981 \hich\af37\dbch\af31505\loch\f37 Parallels RAS Power\hich\af37\dbch\af31505\loch\f37 Shell}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9186981 .
 \par }\pard \ltrpar\s17\ql \li2160\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin2160\itap0\pararsid9138287\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9186981 {\*\shppict
 {\pict{\*\picprop\shplid1026{\sp{\sn shapeType}{\sv 75}}{\sp{\sn fFlipH}{\sv 0}}{\sp{\sn fFlipV}{\sv 0}}{\sp{\sn pibFlags}{\sv 2}}{\sp{\sn fLine}{\sv 0}}{\sp{\sn fLayoutInCell}{\sv 1}}{\sp{\sn fLayoutInCell}{\sv 1}}}
 \picscalex77\picscaley77\piccropl0\piccropr0\piccropt0\piccropb0\picw13099\pich10241\picwgoal7426\pichgoal5806\pngblip\bliptag1151551143{\*\blipuid 44a346a73b2590d690cdaa7b80496bbd}
@@ -19016,8 +19017,7 @@ d68418de8418de8418de8c18d68418de8418de8418de8c18d68418de8418de8418de8c18d68418de
 d68418de8418de8418de8c18d68418de8418de8418de8c18d68418de8418de8418de8c18d68418de8418de8418de8c18d68418000000040000002701ffff030000000000}}}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9186981 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid9138287 \hich\af37\dbch\af31505\loch\f37 b.\tab}}\pard \ltrpar\s17\ql \fi-360\li1440\ri0\sa200\sl276\slmult1
 \nowidctlpar\wrapdefault\faauto\ls2\ilvl1\rin0\lin1440\itap0\pararsid9138287\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9138287 \hich\af37\dbch\af31505\loch\f37 Open an elevated command prompt.
-\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid9138287 \hich\af37\dbch\af31505\loch\f37 c.\tab}\hich\af37\dbch\af31505\loch\f37 Change to the folder \hich\af37\dbch\af31505\loch\f37 containing the RAS installer.
-
+\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid9138287 \hich\af37\dbch\af31505\loch\f37 c.\tab}\hich\af37\dbch\af31505\loch\f37 Change to the folder containing the RAS installer.
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid8284628 \hich\af37\dbch\af31505\loch\f37 d.\tab}}\pard \ltrpar\s17\ql \fi-360\li1440\ri0\sa200\sl276\slmult1
 \nowidctlpar\wrapdefault\faauto\ls2\ilvl1\rin0\lin1440\itap0\pararsid8284628\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid8284628 \hich\af37\dbch\af31505\loch\f37 Type in the following command: }{\rtlch\fcs1 \af2\afs22 
 \ltrch\fcs0 \b\f2\fs22\insrsid8284628\charrsid8284628 \hich\af2\dbch\af31505\loch\f2 msiexec /i RASInstaller-x.y.z.msi /qn ADDLOCAL=F_PowerShell}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid8284628 \hich\af37\dbch\af31505\loch\f37 
@@ -20869,8 +20869,8 @@ a500894c00006ca5c00000002b002b000000c0a56c00a56c2b00c0c0c0004c89c000004c89006c2b
 020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020000040000002701ffff030000000000}}}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid8284628\charrsid9186981 
 \par }\pard \ltrpar\s17\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid10290913\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10290913 
-\par \hich\af37\dbch\af31505\loch\f37 This script was developed using }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid7016631 \hich\af37\dbch\af31505\loch\f37 RAS 1}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid5117009 
-\hich\af37\dbch\af31505\loch\f37 7.1}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10777656 \hich\af37\dbch\af31505\loch\f37  running on Windows Server 201}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid5117009 
+\par \hich\af37\dbch\af31505\loch\f37 This script was developed using\hich\af37\dbch\af31505\loch\f37  }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid7016631 \hich\af37\dbch\af31505\loch\f37 RAS 1}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+\f37\fs22\insrsid5117009 \hich\af37\dbch\af31505\loch\f37 7.1}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10777656 \hich\af37\dbch\af31505\loch\f37  running on Windows Server 201}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid5117009 
 \hich\af37\dbch\af31505\loch\f37 9}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10777656 \hich\af37\dbch\af31505\loch\f37  }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10290913 \hich\af37\dbch\af31505\loch\f37 and PowerShell Version }{
 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13725463 \hich\af37\dbch\af31505\loch\f37 5}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10290913 .}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10777656 
 \hich\af37\dbch\af31505\loch\f37 1}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10290913 \hich\af37\dbch\af31505\loch\f37 . The script was run on Windows }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13725463 
@@ -20896,32 +20896,28 @@ a500894c00006ca5c00000002b002b000000c0a56c00a56c2b00c0c0c0004c89c000004c89006c2b
 \rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 .ps1 }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 and press }{
 \rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 Enter}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 .
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 4.\tab}}\pard \ltrpar\s17\ql \fi-360\li720\ri0\sa200\sl276\slmult1
-\nowidctlpar\wrapdefault\faauto\ls3\rin0\lin720\itap0\pararsid11488686\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 
-By default, a Microsoft Word document is created named after the }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 Forest}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 .}{
-\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 
-\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid14893653 \hich\af37\dbch\af31505\loch\f37 a.\tab}}\pard \ltrpar\s17\ql \fi-360\li1440\ri0\sa200\sl276\slmult1
-\nowidctlpar\wrapdefault\faauto\ls3\ilvl1\rin0\lin1440\itap0\pararsid14893653\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid14893653 \hich\af37\dbch\af31505\loch\f37 For example, WebstersLab.com.docx}{\rtlch\fcs1 \af37\afs22 
-\ltrch\fcs0 \f37\fs22\insrsid14893653\charrsid13987238 
-\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 5.\tab}}\pard \ltrpar\s17\ql \fi-360\li720\ri0\sa200\sl276\slmult1
-\nowidctlpar\wrapdefault\faauto\ls3\rin0\lin720\itap0\pararsid11488686\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 If you use the \hich\f37 \endash \loch\f37 
-PDF option, a PDF file is created named after the }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 Forest}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 .}{\rtlch\fcs1 
-\af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 
-\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid14893653 \hich\af37\dbch\af31505\loch\f37 a.\tab}}\pard \ltrpar\s17\ql \fi-360\li1440\ri0\sa200\sl276\slmult1
-\nowidctlpar\wrapdefault\faauto\ls3\ilvl1\rin0\lin1440\itap0\pararsid14893653\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid14893653 \hich\af37\dbch\af31505\loch\f37 For example, WebstersLab.com.pdf
+\nowidctlpar\wrapdefault\faauto\ls3\rin0\lin720\itap0\pararsid11488686\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 By default, }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+\f37\fs22\insrsid15822428 \hich\af37\dbch\af31505\loch\f37 the script creates }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 a}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+\f37\fs22\insrsid13897747 \hich\af37\dbch\af31505\loch\f37 n HTML file }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 named }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13897747 
+\hich\af37\dbch\af31505\loch\f37 Parallels_RAS.html}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 
+\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 5.\tab}}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 
+\hich\af37\dbch\af31505\loch\f37 If you use the \hich\f37 \endash \loch\f37 PDF option, }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid15822428 \hich\af37\dbch\af31505\loch\f37 the script creates }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+\f37\fs22\insrsid13897747\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 a}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13897747 \hich\af37\dbch\af31505\loch\f37  }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid15822428 
+\hich\af37\dbch\af31505\loch\f37 PDF}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13897747 \hich\af37\dbch\af31505\loch\f37  file }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13897747\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 
+named }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13897747 \hich\af37\dbch\af31505\loch\f37 Parallels_RAS.PDF.}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid6095241\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 6.\tab}}\pard \ltrpar\s17\ql \fi-360\li720\ri0\sa200\sl276\slmult1
 \nowidctlpar\wrapdefault\faauto\ls3\rin0\lin720\itap0\pararsid6095241\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid6095241\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 If you use the \hich\f37 \endash }{\rtlch\fcs1 
-\af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid6095241 \hich\af37\dbch\af31505\loch\f37 HTML}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid6095241\charrsid13987238 \hich\af37\dbch\af31505\loch\f37  option, a}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
-\f37\fs22\insrsid6095241 \hich\af37\dbch\af31505\loch\f37 n HTML}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid6095241\charrsid13987238 \hich\af37\dbch\af31505\loch\f37  file is created named after the }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
-\f37\fs22\insrsid6095241 \hich\af37\dbch\af31505\loch\f37 Forest}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid6095241\charrsid13987238 .}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid6095241 
-\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid6095241 \hich\af37\dbch\af31505\loch\f37 a.\tab}}\pard \ltrpar\s17\ql \fi-360\li1440\ri0\sa200\sl276\slmult1
-\nowidctlpar\wrapdefault\faauto\ls3\ilvl1\rin0\lin1440\itap0\pararsid6095241\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid6095241 \hich\af37\dbch\af31505\loch\f37 For example, WebstersLab.com.html
-\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid6095241\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 7.\tab}}\pard \ltrpar\s17\ql \fi-360\li720\ri0\sa200\sl276\slmult1
-\nowidctlpar\wrapdefault\faauto\ls3\rin0\lin720\itap0\pararsid6095241\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid6095241\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 If you use the \hich\f37 \endash }{\rtlch\fcs1 
-\af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid6095241 \hich\af37\dbch\af31505\loch\f37 Text}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid6095241\charrsid13987238 \hich\af37\dbch\af31505\loch\f37  option, a }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
-\f37\fs22\insrsid6095241 \hich\af37\dbch\af31505\loch\f37 text}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid6095241\charrsid13987238 \hich\af37\dbch\af31505\loch\f37  file is created named after the }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
-\f37\fs22\insrsid6095241 \hich\af37\dbch\af31505\loch\f37 Forest}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid6095241\charrsid13987238 .}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid6095241 
-\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid6095241 \hich\af37\dbch\af31505\loch\f37 a.\tab}}\pard \ltrpar\s17\ql \fi-360\li1440\ri0\sa200\sl276\slmult1
-\nowidctlpar\wrapdefault\faauto\ls3\ilvl1\rin0\lin1440\itap0\pararsid6095241\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid6095241 \hich\af37\dbch\af31505\loch\f37 For example, WebstersLab.com.txt
+\af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13897747 \hich\af37\dbch\af31505\loch\f37 MSWord}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid6095241\charrsid13987238 \hich\af37\dbch\af31505\loch\f37  option, }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+\f37\fs22\insrsid15822428 \hich\af37\dbch\af31505\loch\f37 the script creates }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13897747\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 a}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+\f37\fs22\insrsid13897747 \hich\af37\dbch\af31505\loch\f37  }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid15822428 \hich\af37\dbch\af31505\loch\f37 DOCX}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13897747 
+\hich\af37\dbch\af31505\loch\f37  file }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13897747\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 named }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13897747 
+\hich\af37\dbch\af31505\loch\f37 Parallels_RAS.docx}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid6095241\charrsid13987238 .}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid6095241 
+\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid6095241\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 7.\tab}}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid6095241\charrsid13987238 
+\hich\af37\dbch\af31505\loch\f37 If you use the \hich\f37 \endash }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid6095241 \hich\af37\dbch\af31505\loch\f37 Text}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid6095241\charrsid13987238 
+\hich\af37\dbch\af31505\loch\f37  option, }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid15822428 \hich\af37\dbch\af31505\loch\f37 the script creates }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13897747\charrsid13987238 
+\hich\af37\dbch\af31505\loch\f37 a}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid15822428 \hich\af37\dbch\af31505\loch\f37  Text}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13897747 \hich\af37\dbch\af31505\loch\f37  file }{\rtlch\fcs1 
+\af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13897747\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 named }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13897747 \hich\af37\dbch\af31505\loch\f37 Parallels_RAS.txt}{\rtlch\fcs1 \af37\afs22 
+\ltrch\fcs0 \f37\fs22\insrsid6095241\charrsid13987238 .}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid6095241 
 \par }\pard \ltrpar\s17\ql \li720\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin720\itap0\pararsid6095241\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid6095241 
 \par }\pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid11488686 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 
 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 \hich\af37\dbch\af31505\loch\f37 Full help text is available.
@@ -20940,7 +20936,8 @@ PDF option, a PDF file is created named after the }{\rtlch\fcs1 \af37\afs22 \ltr
 \par \hich\af2\dbch\af31505\loch\f2     C:\\RASScript\\RAS_Inventory_V1.ps1
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 SYNOPSIS
-\par \hich\af2\dbch\af31505\loch\f2     Creates a complete inventory of Parallels Remote Application Server.
+\par \hich\af2\dbch\af31505\loch\f2     Creates a complete inventory of }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9899102 \hich\af2\dbch\af31505\loch\f2 a V17 }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 
+\hich\af2\dbch\af31505\loch\f2 Parallels Remote Application Server.
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 SYNTAX
@@ -20948,39 +20945,43 @@ PDF option, a PDF file is created named after the }{\rtlch\fcs1 \af37\afs22 \ltr
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 [-CompanyAddress <String>]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009 
 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 [-CompanyEmail <String>] [-CompanyFax <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009 
 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 [-C\hich\af2\dbch\af31505\loch\f2 ompanyName <String>] [-CompanyPhone <String>] [-CoverPage}{\rtlch\fcs1 
-\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 <String>] [-Dev] [-Folder }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid5117009 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 [-CompanyName <String>] [-CompanyPhone <String>] [-CoverPage}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5117009 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 <String>] [-Dev] [-Folder }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009 
+
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 <String>] [-From <String>] [-Log] [-ScriptInfo] [-ServerName <String>] [-SmtpPort}{\rtlch\fcs1 \af2\afs18 
 \ltrch\fcs0 \f2\fs18\insrsid5117009 \hich\af2\dbch\af31505\loch\f2  
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2     <Int32>] [-SmtpServer <String>] [-User <String>] [-UserName <String>] [-To <Stri\hich\af2\dbch\af31505\loch\f2 ng>] }{\rtlch\fcs1 \af2\afs18 
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2     <Int32>] [-SmtpServer <S\hich\af2\dbch\af31505\loch\f2 tring>] [-User <String>] [-UserName <String>] [-To <String>] }{\rtlch\fcs1 \af2\afs18 
 \ltrch\fcs0 \f2\fs18\insrsid5117009 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 [-UseSSL] [<CommonParameters>]
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 DESCRIPTION
-\par \hich\af2\dbch\af31505\loch\f2     Creates a complete inventory of Parallels Remote Application Server (RAS) using
+\par \hich\af2\dbch\af31505\loch\f2     Creates a complete inventory of }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9899102 \hich\af2\dbch\af31505\loch\f2 a V17 }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 
+\hich\af2\dbch\af31505\loch\f2 Parallels Remote Application Server (RAS) using
 \par \hich\af2\dbch\af31505\loch\f2     Microsoft PowerShell, Word, plain text, or HTML.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script requires at least PowerShell version 3 but runs \hich\af2\dbch\af31505\loch\f2 best in version 5.
+\par \hich\af2\dbch\af31505\loch\f2     The\hich\af2\dbch\af31505\loch\f2  script requires at least PowerShell version 3 but runs best in version 5.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Word is NOT needed to run the script. This script will output in Text and HTML.
+\par \hich\af2\dbch\af31505\loch\f2     Word is NOT needed to run the script. This script output}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid2110091 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2  in Text and HTML.
 \par \hich\af2\dbch\af31505\loch\f2     The default output format is HTML.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates an output file named RASInventory.<fileextension>.
+\par \hich\af2\dbch\af31505\loch\f2     Creates an output file named }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9899102 \hich\af2\dbch\af31505\loch\f2 Parallels_}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 
+\hich\af2\dbch\af31505\loch\f2 RAS\hich\af2\dbch\af31505\loch\f2 .<fileextension\hich\af2\dbch\af31505\loch\f2 >.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     You do NOT have to run this script on a server running RAS. This script was developed
 \par \hich\af2\dbch\af31505\loch\f2     and run from a Windows 10 VM.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Word and PDF document includes a Cover Page, Table of Contents and Footer.
-\par \hich\af2\dbch\af31505\loch\f2     Includes support for the following language vers\hich\af2\dbch\af31505\loch\f2 ions of Microsoft Word:
+\par \hich\af2\dbch\af31505\loch\f2     Word and PDF document includes a Cover Page, Table of Contents}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid2110091 ,}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 
+\hich\af2\dbch\af31505\loch\f2  and Footer.
+\par \hich\af2\dbch\af31505\loch\f2     Includes support for the following language versions of Microsoft Word:
 \par \hich\af2\dbch\af31505\loch\f2         Catalan
 \par \hich\af2\dbch\af31505\loch\f2         Chinese
 \par \hich\af2\dbch\af31505\loch\f2         Danish
 \par \hich\af2\dbch\af31505\loch\f2         Dutch
 \par \hich\af2\dbch\af31505\loch\f2         English
 \par \hich\af2\dbch\af31505\loch\f2         Finnish
-\par \hich\af2\dbch\af31505\loch\f2         French
+\par \hich\af2\dbch\af31505\loch\f2        \hich\af2\dbch\af31505\loch\f2  French
 \par \hich\af2\dbch\af31505\loch\f2         German
 \par \hich\af2\dbch\af31505\loch\f2         Norwegian
 \par \hich\af2\dbch\af31505\loch\f2         Portuguese
@@ -20989,12 +20990,12 @@ PDF option, a PDF file is created named after the }{\rtlch\fcs1 \af37\afs22 \ltr
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 PARAMETERS
-\par \hich\af2\dbch\af31505\loch\f2     -HTML [<SwitchParameter\hich\af2\dbch\af31505\loch\f2 >]
+\par \hich\af2\dbch\af31505\loch\f2     -HTML [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Creates an HTML file with an .html extension.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         HTML is now the default report format.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is set True if no other output format is selected.
+\par \hich\af2\dbch\af31505\loch\f2         This param\hich\af2\dbch\af31505\loch\f2 eter is set True if no other output format is selected.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
@@ -21003,26 +21004,26 @@ PDF option, a PDF file is created named after the }{\rtlch\fcs1 \af37\afs22 \ltr
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -MSWord [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2 SaveAs DOCX file
+\par \hich\af2\dbch\af31505\loch\f2         SaveAs DOCX file
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Microsoft Word is no longer the default report format.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                Fals\hich\af2\dbch\af31505\loch\f2 e
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -PDF [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         SaveAs PDF file instead of DOCX file.
+\par \hich\af2\dbch\af31505\loch\f2         Sav\hich\af2\dbch\af31505\loch\f2 eAs PDF file instead of DOCX file.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The PDF file is roughly 5X to 10X larger than the DOCX file.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This paramete\hich\af2\dbch\af31505\loch\f2 r requires Microsoft Word to be installed.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter requires Microsoft Word to be installed.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter uses Word's SaveAs PDF capability.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is d\hich\af2\dbch\af31505\loch\f2 isabled by default.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
@@ -21031,28 +21032,30 @@ PDF option, a PDF file is created named after the }{\rtlch\fcs1 \af37\afs22 \ltr
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Text [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Creates a formatted text file with a .txt ext\hich\af2\dbch\af31505\loch\f2 ension.
+\par \hich\af2\dbch\af31505\loch\f2         Creates a formatted text file with a .txt extension.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Position?            \hich\af2\dbch\af31505\loch\f2         named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard cha\hich\af2\dbch\af31505\loch\f2 racters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -AddDateTime [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Adds a date timestamp to the end of the file name.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         The timestamp is in the format of yyyy-MM-dd_HHmm.
-\par \hich\af2\dbch\af31505\loch\f2         June 1, 2019 at 6PM is 2021-06-01_1800.
+\par \hich\af2\dbch\af31505\loch\f2         The tim\hich\af2\dbch\af31505\loch\f2 estamp is in the format of yyyy-MM-dd_HHmm.
+\par \hich\af2\dbch\af31505\loch\f2         June 1, 20}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9899102 \hich\af2\dbch\af31505\loch\f2 22}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 
+ at 6PM is 202}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9899102 \hich\af2\dbch\af31505\loch\f2 2}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 -06-01_1800.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Output filename will be Re\hich\af2\dbch\af31505\loch\f2 portName_2021-06-01_1800.<ext>.
+\par \hich\af2\dbch\af31505\loch\f2         Output filename will be ReportName_202}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9899102 \hich\af2\dbch\af31505\loch\f2 2}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 
+\hich\af2\dbch\af31505\loch\f2 -06-01_1800.<ext>.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of ADT.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
@@ -21061,50 +21064,50 @@ PDF option, a PDF file is created named after the }{\rtlch\fcs1 \af37\afs22 \ltr
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyAddress <String>
 \par \hich\af2\dbch\af31505\loch\f2         Company Address to use for the Cover Page, if the Cover Page has the Address field.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     The following Cover Pages have an Address field:
+\par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have an Address field:
 \par \hich\af2\dbch\af31505\loch\f2                 Banded (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010)
-\par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010)
+\par \hich\af2\dbch\af31505\loch\f2                 Exposure (Wor\hich\af2\dbch\af31505\loch\f2 d 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Filigree (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Ion (Dark) (Word 2013/2016)
-\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2              Retrospect (Word 2013/2016)
+\par \hich\af2\dbch\af31505\loch\f2                 Retrospect (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Semaphore (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Tiles (Word 2010)
-\par \hich\af2\dbch\af31505\loch\f2                 ViewMaster (Word 2013/2016)
+\par \hich\af2\dbch\af31505\loch\f2                 ViewMaster (Word 2013/201\hich\af2\dbch\af31505\loch\f2 6)
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
-\par \hich\af2\dbch\af31505\loch\f2         This \hich\af2\dbch\af31505\loch\f2 parameter has an alias of CA.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CA.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipel\hich\af2\dbch\af31505\loch\f2 ine input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -CompanyEmail <String>
+\par \hich\af2\dbch\af31505\loch\f2         Company Email to use for the Cover Page\hich\af2\dbch\af31505\loch\f2  if the Cover Page has the Email field.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have an Email field:
+\par \hich\af2\dbch\af31505\loch\f2                 Facet (Word 2013/2016)
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CE.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    \hich\af2\dbch\af31505\loch\f2 false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -CompanyEmail <String>
-\par \hich\af2\dbch\af31505\loch\f2         Company Email to use for the Cover Page, if the Cover Page has the Email field.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have an Email field:
-\par \hich\af2\dbch\af31505\loch\f2                 Facet (Word 2013/2016)
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the\hich\af2\dbch\af31505\loch\f2  MSWORD and PDF output parameters.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CE.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard ch\hich\af2\dbch\af31505\loch\f2 aracters?  false
-\par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyFax <String>
-\par \hich\af2\dbch\af31505\loch\f2         Company Fax to use for the Cover Page, if the Cover Page has the Fax field.
+\par \hich\af2\dbch\af31505\loch\f2         Company Fax to use for the Cover Page\hich\af2\dbch\af31505\loch\f2  if the Cover Page has the \hich\af2\dbch\af31505\loch\f2 Fax field.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have a Fax field:
 \par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010)
 \par 
-\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2        This parameter is only valid with the MSWORD and PDF output parameters.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CF.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias o\hich\af2\dbch\af31505\loch\f2 f CF.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
@@ -21115,27 +21118,27 @@ PDF option, a PDF file is created named after the }{\rtlch\fcs1 \af37\afs22 \ltr
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyName <String>
 \par \hich\af2\dbch\af31505\loch\f2         Company Name to use for the Cover Page.
 \par \hich\af2\dbch\af31505\loch\f2         The default value is contained in
-\par \hich\af2\dbch\af31505\loch\f2         HKCU:\\Software\\Microsoft\\Office\\Common\\UserIn\hich\af2\dbch\af31505\loch\f2 fo\\CompanyName or
+\par \hich\af2\dbch\af31505\loch\f2         HKCU:\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName or
 \par \hich\af2\dbch\af31505\loch\f2         HKCU:\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company, whichever is populated
-\par \hich\af2\dbch\af31505\loch\f2         on the computer running the script.
+\par \hich\af2\dbch\af31505\loch\f2        \hich\af2\dbch\af31505\loch\f2  on the computer running the script.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter ha\hich\af2\dbch\af31505\loch\f2 s an alias of CN.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CN.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value
+\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2 Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyPhone <String>
-\par \hich\af2\dbch\af31505\loch\f2         Company\hich\af2\dbch\af31505\loch\f2  Phone to use for the Cover Page if the Cover Page has the Phone field.
+\par \hich\af2\dbch\af31505\loch\f2         Company Phone to use for the Cover Page if the Cover Page has the Phone field.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have a Phone field:
+\par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have a\hich\af2\dbch\af31505\loch\f2  Phone field:
 \par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010)
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD a\hich\af2\dbch\af31505\loch\f2 nd PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CPh.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
@@ -21146,54 +21149,60 @@ PDF option, a PDF file is created named after the }{\rtlch\fcs1 \af37\afs22 \ltr
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CoverPage <String>
 \par \hich\af2\dbch\af31505\loch\f2         What Microsoft Word Cover Page to use.
-\par \hich\af2\dbch\af31505\loch\f2         Only Word 2010, 2013 and 2016 are supported.
+\par \hich\af2\dbch\af31505\loch\f2         Only Word 2010, 2013}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4546918 ,}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2  and 2016 are supported.
+
 \par \hich\af2\dbch\af31505\loch\f2         (default cover pages in Word en-US)
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Valid input is:
 \par \hich\af2\dbch\af31505\loch\f2                 Alphabet (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Annual (Word 2010. Doesn't work well for this report)
+\par \hich\af2\dbch\af31505\loch\f2                 Annual (Word 2010. Doesn't \hich\af2\dbch\af31505\loch\f2 work well for this report)
 \par \hich\af2\dbch\af31505\loch\f2                 Austere (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Austin (Word 2010/2013/2016. Doesn't work in 2013 or 2016, \hich\af2\dbch\af31505\loch\f2 mostly
-\par \hich\af2\dbch\af31505\loch\f2                 works in 2010 but Subtitle/Subject & Author fields need to be moved
-\par \hich\af2\dbch\af31505\loch\f2                 after title box is moved up)
+\par \hich\af2\dbch\af31505\loch\f2                 Austin (Word 2010/2013/2016. Doesn't work in 2013 or 2016, mostly
+\par \hich\af2\dbch\af31505\loch\f2                 works in 2010}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 ,}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 
+ but Subtitle/Subject & Author fields need }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2 moving }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 
+after }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2 the 
+\par \hich\af2\dbch\af31505\loch\f2              \hich\af2\dbch\af31505\loch\f2    }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 title box is moved up)
 \par \hich\af2\dbch\af31505\loch\f2                 Banded (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Conservative (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Contrast \hich\af2\dbch\af31505\loch\f2 (Word 2010. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Cubicles (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010. Works if you like looking sideways)
+\par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010. Works if y\hich\af2\dbch\af31505\loch\f2 ou like looking sideways)
 \par \hich\af2\dbch\af31505\loch\f2                 Facet (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Filigree (Word 2013/2016. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Grid (Wor\hich\af2\dbch\af31505\loch\f2 d 2010/2013/2016. Works in 2010)
+\par \hich\af2\dbch\af31505\loch\f2                 Grid (Word 2010/2013/2016. Works in 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Integral (Word 2013/2016. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Ion (Dark) (Word 2013/2016. Top date doesn't fit; box needs to be
+\par \hich\af2\dbch\af31505\loch\f2                 Ion (Dark) (\hich\af2\dbch\af31505\loch\f2 Word 2013/2016. Top date doesn't fit; box needs to be
 \par \hich\af2\dbch\af31505\loch\f2                 manually resized or font changed to 8 point)
-\par \hich\af2\dbch\af31505\loch\f2        \hich\af2\dbch\af31505\loch\f2          Ion (Light) (Word 2013/2016. Top date doesn't fit; box needs to be
-\par \hich\af2\dbch\af31505\loch\f2                 manually resized or font changed to 8 point)
+\par \hich\af2\dbch\af31505\loch\f2                 Ion (Light) (Word 2013/2016. Top date doesn't fit; box needs to be
+\par \hich\af2\dbch\af31505\loch\f2                 manually resized or font changed to 8 poin\hich\af2\dbch\af31505\loch\f2 t)
 \par \hich\af2\dbch\af31505\loch\f2                 Mod (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Motion (Word 2010/2013/2016. Works if top date is manually chang\hich\af2\dbch\af31505\loch\f2 ed to
+\par \hich\af2\dbch\af31505\loch\f2                 Motion (Word 2010/2013/2016. Works if }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2 the }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 top date is manually changed to
 \par \hich\af2\dbch\af31505\loch\f2                 36 point)
-\par \hich\af2\dbch\af31505\loch\f2                 Newsprint (Word 2010. Works but date is not populated)
+\par \hich\af2\dbch\af31505\loch\f2                 Newsprint (Word 2010. Works but }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2 the }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 
+\hich\af2\dbch\af31505\loch\f2 date is not populated)
 \par \hich\af2\dbch\af31505\loch\f2                 Perspective (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Pinstripes (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Puzzle (Word 2010. Top date doesn't fit; box\hich\af2\dbch\af31505\loch\f2  needs to be manually
+\par \hich\af2\dbch\af31505\loch\f2                 Puzzle (Word 2010. Top date doesn't fit; box needs to be manually
 \par \hich\af2\dbch\af31505\loch\f2                 resized or font changed to 14 point)
-\par \hich\af2\dbch\af31505\loch\f2                 Retrospect (Word 2013/2016. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Retrospect (\hich\af2\dbch\af31505\loch\f2 Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Semaphore (Word 2013/2016. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Sideline (Word 2010/2013/2016. Doesn't work in 2013 or 2016, wor\hich\af2\dbch\af31505\loch\f2 ks in
+\par \hich\af2\dbch\af31505\loch\f2                 Sideline (Word 2010/2013/2016. Doesn't work in 2013 or 2016}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2 . W}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 orks in
 \par \hich\af2\dbch\af31505\loch\f2                 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Slice (Dark) (Word 2013/2016. Doesn't work)
-\par \hich\af2\dbch\af31505\loch\f2                 Slice (Light) (Word 2013/2016. Doesn't work)
+\par \hich\af2\dbch\af31505\loch\f2                \hich\af2\dbch\af31505\loch\f2  Slice (Light) (Word 2013/2016. Doesn't work)
 \par \hich\af2\dbch\af31505\loch\f2                 Stacks (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Tiles (Word 2010. Date doesn't fit unless changed\hich\af2\dbch\af31505\loch\f2  to 26 point)
+\par \hich\af2\dbch\af31505\loch\f2                 Tiles (Word 2010. Date doesn't fit unless changed to 26 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Transcend (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 ViewMaster (Word 2013/2016. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 ViewMaster (Word 2013/2016. \hich\af2\dbch\af31505\loch\f2 Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Whisp (Word 2013/2016. Works)
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The default value is Sideline.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CP.
-\par \hich\af2\dbch\af31505\loch\f2         This para\hich\af2\dbch\af31505\loch\f2 meter is only valid with the MSWORD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    fa\hich\af2\dbch\af31505\loch\f2 lse
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                Sideline
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
@@ -21203,32 +21212,32 @@ PDF option, a PDF file is created named after the }{\rtlch\fcs1 \af37\afs22 \ltr
 \par \hich\af2\dbch\af31505\loch\f2         Clears errors at the beginning of the script.
 \par \hich\af2\dbch\af31505\loch\f2         Outputs all errors to a text file at the end of the script.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This is u\hich\af2\dbch\af31505\loch\f2 sed when the script developer requests more troubleshooting data.
-\par \hich\af2\dbch\af31505\loch\f2         The text file is placed in the same folder from where the script is run.
+\par \hich\af2\dbch\af31505\loch\f2         This is used when the script developer requests more troubleshooting data.
+\par \hich\af2\dbch\af31505\loch\f2         The text file is placed in the same folder\hich\af2\dbch\af31505\loch\f2  from where the script is run.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?\hich\af2\dbch\af31505\loch\f2                     named
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Folder <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the optional output folder to save the output report.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2   Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept\hich\af2\dbch\af31505\loch\f2  pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -From <String>
-\par \hich\af2\dbch\af31505\loch\f2         Specifies the username for the From emai\hich\af2\dbch\af31505\loch\f2 l address.
+\par \hich\af2\dbch\af31505\loch\f2         Specifies the username for the From email address.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         If SmtpServer or To are used, this is a required parameter.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Required?                  \hich\af2\dbch\af31505\loch\f2   false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
@@ -21239,52 +21248,53 @@ PDF option, a PDF file is created named after the }{\rtlch\fcs1 \af37\afs22 \ltr
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2      Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard character\hich\af2\dbch\af31505\loch\f2 s?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -ScriptInfo [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Outputs information about the script to a text file.
-\par \hich\af2\dbch\af31505\loch\f2         The text file is placed \hich\af2\dbch\af31505\loch\f2 in the same folder from where the script is run.
+\par \hich\af2\dbch\af31505\loch\f2         The text file is placed in the same folder from where the script is run.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of SI.
+\par \hich\af2\dbch\af31505\loch\f2         This parame\hich\af2\dbch\af31505\loch\f2 ter has an alias of SI.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value        \hich\af2\dbch\af31505\loch\f2         False
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -ServerName <String>
+\par \hich\af2\dbch\af31505\loch\f2     -ServerName\hich\af2\dbch\af31505\loch\f2  <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies which RAS server to use to run the script against.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         ServerName can be entered as the NetBIOS name, FQDN, localhost or IP Address.
+\par \hich\af2\dbch\af31505\loch\f2         ServerName can be entered as the NetBIOS name, FQDN, localhost}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4546918 ,}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 
+\hich\af2\dbch\af31505\loch\f2  or IP Address.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         If entered as localhost, the actual computer name is determined and used.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         If enter\hich\af2\dbch\af31505\loch\f2 ed as an IP address, an attempt is made to determine and use the actual
+\par \hich\af2\dbch\af31505\loch\f2         If entered as an IP address, an attempt is made to determine and use the actual
 \par \hich\af2\dbch\af31505\loch\f2         computer name.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Default value is LocalHost
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Required?        \hich\af2\dbch\af31505\loch\f2             false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                L\hich\af2\dbch\af31505\loch\f2 ocalHost
+\par \hich\af2\dbch\af31505\loch\f2         Default value                LocalHost
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -SmtpPort <Int32>
-\par \hich\af2\dbch\af31505\loch\f2         Specifies the SMTP port for the SmtpServer.
+\par \hich\af2\dbch\af31505\loch\f2         Specifies the SMTP port for the\hich\af2\dbch\af31505\loch\f2  SmtpServer.
 \par \hich\af2\dbch\af31505\loch\f2         The default is 25.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Positio\hich\af2\dbch\af31505\loch\f2 n?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                25
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -SmtpServer <String>
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   -SmtpServer <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the optional email server to send the output report(s).
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         If From or To are used, this is a required parameter.
@@ -21292,21 +21302,21 @@ PDF option, a PDF file is created named after the }{\rtlch\fcs1 \af37\afs22 \ltr
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Ac\hich\af2\dbch\af31505\loch\f2 cept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -User <String>
 \par \hich\af2\dbch\af31505\loch\f2         Username to use for the connection to the RAS server.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Default value is contained in $env:username
+\par \hich\af2\dbch\af31505\loch\f2         Default value \hich\af2\dbch\af31505\loch\f2 is contained in $env:username
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2        Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                $env:username
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -UserName <String>
+\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2    -UserName <String>
 \par \hich\af2\dbch\af31505\loch\f2         Username to use for the Cover Page and Footer.
 \par \hich\af2\dbch\af31505\loch\f2         The default value is contained in $env:username
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of UN.
@@ -21319,38 +21329,38 @@ PDF option, a PDF file is created named after the }{\rtlch\fcs1 \af37\afs22 \ltr
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -To <String>
-\par \hich\af2\dbch\af31505\loch\f2         Specifi\hich\af2\dbch\af31505\loch\f2 es the username for the To email address.
+\par \hich\af2\dbch\af31505\loch\f2         Specifies the username for the To email address.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         If SmtpServer or From are used, this is a required parameter.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Position?      \hich\af2\dbch\af31505\loch\f2               named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?    \hich\af2\dbch\af31505\loch\f2    false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -UseSSL [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Specifies whether to use SSL for the SmtpServer.
 \par \hich\af2\dbch\af31505\loch\f2         The default is False.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    nam\hich\af2\dbch\af31505\loch\f2 ed
+\par \hich\af2\dbch\af31505\loch\f2        \hich\af2\dbch\af31505\loch\f2  Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     <CommonParameters>
-\par \hich\af2\dbch\af31505\loch\f2         This cmdlet supports the common parameters: Verbose, Debug,
+\par \hich\af2\dbch\af31505\loch\f2         This cmdlet supp\hich\af2\dbch\af31505\loch\f2 orts the common parameters: Verbose, Debug,
 \par \hich\af2\dbch\af31505\loch\f2         ErrorAction, ErrorVariable, WarningAction, WarningVariable,
 \par \hich\af2\dbch\af31505\loch\f2         OutBuffer, PipelineVariable, and OutVariable. For more information, see
-\par \hich\af2\dbch\af31505\loch\f2         about_CommonParameters (}{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8726130 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 
-HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8726130 {\*\datafield 
+\par \hich\af2\dbch\af31505\loch\f2         about_CommonParameters (}{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8726130 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://go.microsoft\hich\af2\dbch\af31505\loch\f2 
+.com/fwlink/?LinkID=113216" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8726130 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b76000000680074007400700073003a002f002f0067006f002e006d006900630072006f0073006f00660074002e0063006f006d002f00660077006c0069006e006b002f003f004c0069006e006b00490044003d003100
-310033003200310036000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid5117009\charrsid8726130 \hich\af2\dbch\af31505\loch\f2 https:/go.microsoft.com/fwlink/?LinkID=113216}}}
-\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 ).
+310033003200310036000000795881f43b1d7f48af2c825dc485276300000000a5ab000300000fbe}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid5117009\charrsid8726130 \hich\af2\dbch\af31505\loch\f2 
+https:/go.microsoft.com/fwlink/?LinkID=113216}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 ).
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 INPUTS
-\par \hich\af2\dbch\af31505\loch\f2     None.  You canno\hich\af2\dbch\af31505\loch\f2 t pipe objects to this script.
+\par \hich\af2\dbch\af31505\loch\f2     None.  You cannot pipe objects to this script.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 OUTPUTS
 \par \hich\af2\dbch\af31505\loch\f2     No objects are output from this script. This script creates a Word, PDF, HTML, or plain
@@ -21358,9 +21368,10 @@ HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 NOTES
 \par \hich\af2\dbch\af31505\loch\f2         NAME: RAS_Inventory_V1.ps1
-\par \hich\af2\dbch\af31505\loch\f2         VERSION: 0.80
-\par \hich\af2\dbch\af31505\loch\f2         AUTHOR: Carl Webster
-\par \hich\af2\dbch\af31505\loch\f2         LAST\hich\af2\dbch\af31505\loch\f2 EDIT: August 1, 2020
+\par \hich\af2\dbch\af31505\loch\f2         VERSION: }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13897747 \hich\af2\dbch\af31505\loch\f2 1.01}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 
+\par \hich\af2\dbch\af31505\loch\f2         AUTHOR: Carl \hich\af2\dbch\af31505\loch\f2 Webster
+\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13897747 \hich\af2\dbch\af31505\loch\f2 April 19, 202}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid2110091 \hich\af2\dbch\af31505\loch\f2 1}{
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 1 --------------------------
 \par 
@@ -21372,7 +21383,7 @@ HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ----------------------\hich\af2\dbch\af31505\loch\f2 ---- EXAMPLE 2 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     --\hich\af2\dbch\af31505\loch\f2 ------------------------ EXAMPLE 2 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\RAS_Inventory_V1.ps1 -MSWord -CompanyName "Carl Webster }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 Consulting"}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009 \hich\af2\dbch\af31505\loch\f2  }{
@@ -21382,10 +21393,10 @@ HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505
 \par \hich\af2\dbch\af31505\loch\f2         Carl Webster Consulting for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2         Mod for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2         Carl Webster for the User Name.
-\par \hich\af2\dbch\af31505\loch\f2         RAS server named RAS01 for the Compute\hich\af2\dbch\af31505\loch\f2 rName.
+\par \hich\af2\dbch\af31505\loch\f2         RAS server named RAS01 for the ComputerName.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Outputs to Microsoft Word.
-\par \hich\af2\dbch\af31505\loch\f2     Prompts for credentials for the RAS Server RAS01.
+\par \hich\af2\dbch\af31505\loch\f2     Prompts for credentials for the RA\hich\af2\dbch\af31505\loch\f2 S Server RAS01.
 \par 
 \par 
 \par 
@@ -21393,58 +21404,60 @@ HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 3 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\RAS_Inventory_V1.ps1 -PDF -CN "Carl Webster Consulting" -CP }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009 
-\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2    }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 "Mod"}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009 
-\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 -UN "Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 "Mod"}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 
+\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 -UN "Carl Webster"
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
-\par \hich\af2\dbch\af31505\loch\f2         Carl Webster Consulting for the Company Name (alias CN).
+\par \hich\af2\dbch\af31505\loch\f2         C\hich\af2\dbch\af31505\loch\f2 arl Webster Consulting for the Company Name (alias CN).
 \par \hich\af2\dbch\af31505\loch\f2         Mod for the Cover Page format (alias CP).
 \par \hich\af2\dbch\af31505\loch\f2         Carl Webster for the User Name (alias UN).
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Outputs to PDF.
-\par \hich\af2\dbch\af31505\loch\f2     Prompts for credential\hich\af2\dbch\af31505\loch\f2 s for the LocalHost RAS Server.
+\par \hich\af2\dbch\af31505\loch\f2     Prompts for credentials for the LocalHost RAS Server.
 \par 
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 4 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     ------------\hich\af2\dbch\af31505\loch\f2 -------------- EXAMPLE 4 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\RAS_Inventory_V1.ps1 -CompanyName "Sherlock Holmes}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009 \hich\af2\dbch\af31505\loch\f2  
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2     Consulting"
-\par \hich\af2\dbch\af31505\loch\f2     -CoverPage Exposure
-\par \hich\af2\dbch\af31505\loch\f2     -UserName "Dr. Watson"
-\par \hich\af2\dbch\af31505\loch\f2     -CompanyAddress "221B Baker Street, London, England"
-\par \hich\af2\dbch\af31505\loch\f2     -CompanyFax "+44 1753 276600"
-\par \hich\af2\dbch\af31505\loch\f2     -CompanyPhone "+44 1753 276200"
-\par \hich\af2\dbch\af31505\loch\f2     -MSWord
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\RAS_Inventory_V1.ps1 -CompanyName "Sherlock Holmes}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 Consulting"}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009 
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2     -CoverPage Exposure}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 -UserName "Dr. Watson"}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 -CompanyAddress "221B Baker Street, London, }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 England"}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2  }{
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 -CompanyFax "+44 1753 276600"}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 -CompanyPhone "+44 1753 276200"}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 -MSWord
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
 \par \hich\af2\dbch\af31505\loch\f2         Sherlock Holmes Consulting for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2         Exposure f\hich\af2\dbch\af31505\loch\f2 or the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2         Dr. Watson for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2         Exposure for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2         Dr. \hich\af2\dbch\af31505\loch\f2 Watson for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2         221B Baker Street, London, England for the Company Address.
 \par \hich\af2\dbch\af31505\loch\f2         +44 1753 276600 for the Company Fax.
 \par \hich\af2\dbch\af31505\loch\f2         +44 1753 276200 for the Company Phone.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Outputs to Microsoft Word.
-\par \hich\af2\dbch\af31505\loch\f2     Prompts for credentials for the LocalHost RAS Server.
+\par \hich\af2\dbch\af31505\loch\f2     Prompts for credentials for the Lo\hich\af2\dbch\af31505\loch\f2 cal}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2 h}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 ost RAS Server.
 \par 
 \par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 5 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\\hich\af2\dbch\af31505\loch\f2 RAS_Inventory_V1.ps1 -CompanyName "Sherlock Holmes}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 
-\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 
-\par \hich\af2\dbch\af31505\loch\f2     Consulting"
-\par \hich\af2\dbch\af31505\loch\f2     -CoverPage Facet
-\par \hich\af2\dbch\af31505\loch\f2     -UserName "Dr. Watson"
-\par \hich\af2\dbch\af31505\loch\f2     -CompanyEmail SuperSleuth@SherlockHolmes.com
-\par \hich\af2\dbch\af31505\loch\f2     -PDF
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\RAS_Inventory_V1.ps1 -CompanyName "Sherlock Holmes}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 Consulting"}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009 
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2     -CoverPage Facet}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 -UserName "Dr. Watson"}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 -CompanyEmail }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428\charrsid15822428 \hich\af2\dbch\af31505\loch\f2 SuperSleuth@S\hich\af2\dbch\af31505\loch\f2 
+herlockHolmes.com}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009 
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2     -PDF
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
 \par \hich\af2\dbch\af31505\loch\f2         Sherlock Holmes Consulting for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2         Fa\hich\af2\dbch\af31505\loch\f2 cet for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2         Facet for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2         Dr. Watson for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2         SuperSleuth@SherlockHolmes.com for the Company Email.
 \par 
@@ -21456,60 +21469,77 @@ HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 6 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\RAS_Inventory_V1.ps1
-\par \hich\af2\dbch\af31505\loch\f2     -SmtpServer mail.domain.tld
-\par \hich\af2\dbch\af31505\loch\f2     -From XDAdmin@domain.tld
-\par \hich\af2\dbch\af31505\loch\f2     -To ITGroup@domain.tld
-\par \hich\af2\dbch\af31505\loch\f2     -Text
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\RAS_Inventory_V1.ps1}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 
+\hich\af2\dbch\af31505\loch\f2 -SmtpServer mail.domain.tld}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 
+\hich\af2\dbch\af31505\loch\f2 -From }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428\charrsid15822428 \hich\af2\dbch\af31505\loch\f2 XDAdmin@domain.tld}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 
+\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 -To }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428\charrsid15822428 \hich\af2\dbch\af31505\loch\f2 
+ITGroup@domain.tld}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 -Text
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script will use the email server mail.domain.tld, sending from XDAdmin@domain.t\hich\af2\dbch\af31505\loch\f2 ld,
+\par \hich\af2\dbch\af31505\loch\f2     The script }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2 u}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 se}{
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 
+ the email server mail.domain.tld, sending from XDAdmin@domain.tld,
 \par \hich\af2\dbch\af31505\loch\f2     sending to ITGroup@domain.tld.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script will use the default SMTP port 25 and will not use SSL.
+\par \hich\af2\dbch\af31505\loch\f2     The script use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 
+ the default SMTP port 25 and }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2 does }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 not use SSL.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send email,
-\par \hich\af2\dbch\af31505\loch\f2     the user will be prompted to enter valid credentials.
+\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials a\hich\af2\dbch\af31505\loch\f2 re not valid to send }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2 an }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 email,}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 
+\hich\af2\dbch\af31505\loch\f2 the }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2 script prompts 
+\par \hich\af2\dbch\af31505\loch\f2     the user }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 to enter valid credentials.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Outputs to a text file.
-\par \hich\af2\dbch\af31505\loch\f2     Prompts for credentials for the LocalHost RAS Server.
+\par \hich\af2\dbch\af31505\loch\f2     Prompts for credentials for the Local}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2 h}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 
+\hich\af2\dbch\af31505\loch\f2 ost RAS Server.
 \par 
 \par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 7 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\RAS_Inventory_V1\hich\af2\dbch\af31505\loch\f2 .ps1
-\par \hich\af2\dbch\af31505\loch\f2     -SmtpServer mailrelay.domain.tld
-\par \hich\af2\dbch\af31505\loch\f2     -From Anonymous@domain.tld
-\par \hich\af2\dbch\af31505\loch\f2     -To ITGroup@domain.tld
+\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2 PS C:\\PSScript >.\\RAS_Inventory_V1.ps1}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 -SmtpServer mailrelay.domain.tld}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 -From }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428\charrsid15822428 \hich\af2\dbch\af31505\loch\f2 Anonymous@domain.tld}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 
+\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 -To ITGroup@domain.tld
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ***SENDING UNAUTHENTICATED EMAIL***
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script will use the email server mailrelay.domain.tld, sending from
-\par \hich\af2\dbch\af31505\loch\f2     anonymous@domain.tld, sending to I\hich\af2\dbch\af31505\loch\f2 TGroup@domain.tld.
+\par \hich\af2\dbch\af31505\loch\f2     The script use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 
+ the email server mailrelay.domain.tld, sending from
+\par \hich\af2\dbch\af31505\loch\f2     anonymous@domain.tld, sending to ITGroup@domain.tld.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     To send unauthenticated email using an email relay server requires the From email account
-\par \hich\af2\dbch\af31505\loch\f2     to use the name Anonymous.
+\par \hich\af2\dbch\af31505\loch\f2     To send }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2 an }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 
+unauthenticated email using an email relay server requires the From email }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 account}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2  }{
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 to use the name Anonymous.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script will use the default SMTP port 25 and will not use SSL.
+\par \hich\af2\dbch\af31505\loch\f2     The script use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 
+ the default SMTP port 25 and }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2 does}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2  not use SSL.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ***GMAIL/G SUITE SMTP RELAY***
-\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8726130 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 HYPERLINK "https://support.google.com/a/answer/2956491?hl=en"
-\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8726130 {\*\datafield 
+\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8726130 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://support.google.com/a/answer/2956491?hl=en" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid8726130 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7c000000680074007400700073003a002f002f0073007500700070006f00720074002e0067006f006f0067006c0065002e0063006f006d002f0061002f0061006e0073007700650072002f0032003900350036003400
-390031003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid5117009\charrsid8726130 \hich\af2\dbch\af31505\loch\f2 
+390031003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab0003304600a9}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid5117009\charrsid8726130 \hich\af2\dbch\af31505\loch\f2 
 https://support.google.com/a/answer/2956491?hl=en}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 
-\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8726130 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 HYPERLINK "https://support.google.com/a/answer/176600?hl=en"
-\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8726130 {\*\datafield 
+\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid8726130 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://support.google.com/a/answer/176600?hl=en" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid8726130 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7a000000680074007400700073003a002f002f0073007500700070006f00720074002e0067006f006f0067006c0065002e0063006f006d002f0061002f0061006e0073007700650072002f0031003700360036003000
-30003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid5117009\charrsid8726130 \hich\af2\dbch\af31505\loch\f2 
+30003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab0003440734c2}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid5117009\charrsid8726130 \hich\af2\dbch\af31505\loch\f2 
 https://support.google.com/a/answer/176600?hl=en}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     To send email using a Gmail or g-suite account, you may have to turn ON
-\par \hich\af2\dbch\af31505\loch\f2     the "Less secure app access" opti\hich\af2\dbch\af31505\loch\f2 on on your account.
-\par \hich\af2\dbch\af31505\loch\f2     ***GMAIL/G SUITE SMTP RELAY***
+\par \hich\af2\dbch\af31505\loch\f2     To send }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2 an }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 
+email using a Gmail or g-suite account, you may have to turn ON}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 
+\hich\af2\dbch\af31505\loch\f2 the "Less }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 secure app access" option on your account.}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009 
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428\charrsid5117009 
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2     ***GMAIL/G S\hich\af2\dbch\af31505\loch\f2 UITE SMTP RELAY***
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script will generate an anonymous secure password for the anonymous@domain.tld
+\par \hich\af2\dbch\af31505\loch\f2     The script generate}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 
+\hich\af2\dbch\af31505\loch\f2  an anonymous}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 ,}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 
+ secure password for the anonymous@domain.tld
 \par \hich\af2\dbch\af31505\loch\f2     account.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Outputs, by default, to HTML.
@@ -21518,53 +21548,63 @@ https://support.google.com/a/answer/176600?hl=en}}}\sectd \ltrsect\linex0\sectde
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2  -------------------------- EXAMPLE 8 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 8 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\RAS_Inventory_V1.ps1
-\par \hich\af2\dbch\af31505\loch\f2     -SmtpServer labaddomain-com.mail.protection.outlook.com
-\par \hich\af2\dbch\af31505\loch\f2     -UseSSL
-\par \hich\af2\dbch\af31505\loch\f2     -From SomeEmailAddress@labaddomain.com
-\par \hich\af2\dbch\af31505\loch\f2     -To ITGroupDL@labaddomain.co\hich\af2\dbch\af31505\loch\f2 m
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\RAS_Inventory_V1.ps1}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 
+\hich\af2\dbch\af31505\loch\f2 -SmtpServer }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 
+\par \hich\af2\dbch\af31505\loch\f2     l}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 abaddomain-com.mail.protection.outlook.com}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 
+\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 -UseSSL}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 
+\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 -From }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428\charrsid15822428 \hich\af2\dbch\af31505\loch\f2 SomeEmailAddress@labaddomain.com}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 
+\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 -To ITGroupDL@labaddomain.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ***OFFICE 365 Example***
-\par 
 \par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009 \hich\af2\dbch\af31505\loch\f2 
  HYPERLINK "https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multifunction-device-or-application-to-send-email-using-office-3" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b40010000680074007400700073003a002f002f0064006f00630073002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f00650078006300680061006e0067006500
 2f006d00610069006c002d0066006c006f0077002d0062006500730074002d007000720061006300740069006300650073002f0068006f0077002d0074006f002d007300650074002d00750070002d0061002d006d0075006c0074006900660075006e006300740069006f006e002d006400650076006900630065002d006f
-0072002d006100700070006c00690063006100740069006f006e002d0074006f002d00730065006e0064002d0065006d00610069006c002d007500730069006e0067002d006f00660066006900630065002d0033000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 
-\af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multifunctio\hich\af2\dbch\af31505\loch\f2 
-n-device-or-application-to-send-email-using-office-3}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 
+0072002d006100700070006c00690063006100740069006f006e002d0074006f002d00730065006e0064002d0065006d00610069006c002d007500730069006e0067002d006f00660066006900630065002d0033000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000074000e30}}}{\fldrslt {
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 https://docs.microsoft.com/en-us/exchange/mail-flow-best-practice\hich\af2\dbch\af31505\loch\f2 
+s/how-to-set-up-a-multifunction-device-or-application-to-send-email-using-office-3}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     This uses Option 2 from the above link.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ***OFFICE 365 Example***
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script will use the email server labaddomain-com.mail.protection.outlook.com,
-\par \hich\af2\dbch\af31505\loch\f2     sending from SomeEmailAddress@labaddomain.com, sending to ITGroupDL@labaddomain.com.
+\par \hich\af2\dbch\af31505\loch\f2     The script use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 
+ the email server labaddomain-com.mail.protection.outlook.com,
+\par \hich\af2\dbch\af31505\loch\f2     sending \hich\af2\dbch\af31505\loch\f2 from SomeEmailAddress@labaddomain.com, }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2 and }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 sending to }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 ITGroupDL@labaddomain.com.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script will use the default SMTP port 25 and will use SSL.
+\par \hich\af2\dbch\af31505\loch\f2     The script use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 
+ the default SMTP port 25 and SSL.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Outputs,\hich\af2\dbch\af31505\loch\f2  by default, to HTML.
+\par \hich\af2\dbch\af31505\loch\f2     Outputs, by default, to HTML.
 \par \hich\af2\dbch\af31505\loch\f2     Prompts for credentials for the LocalHost RAS Server.
 \par 
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 9 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     --------------\hich\af2\dbch\af31505\loch\f2 ------------ EXAMPLE 9 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\RAS_Inventory_V1.ps1
-\par \hich\af2\dbch\af31505\loch\f2     -SmtpServer smtp.office365.com
-\par \hich\af2\dbch\af31505\loch\f2     -SmtpPort 587
-\par \hich\af2\dbch\af31505\loch\f2     -Us\hich\af2\dbch\af31505\loch\f2 eSSL
-\par \hich\af2\dbch\af31505\loch\f2     -From Webster@CarlWebster.com
-\par \hich\af2\dbch\af31505\loch\f2     -To ITGroup@CarlWebster.com
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\RAS_Inventory_V1.ps1}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 
+\hich\af2\dbch\af31505\loch\f2 -SmtpServer smtp.office365.com}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 
+\hich\af2\dbch\af31505\loch\f2 -SmtpPort 587}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009 
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2     -UseSSL}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 -From }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428\charrsid15822428 \hich\af2\dbch\af31505\loch\f2 Webster@CarlWebster.com}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 -To ITGroup@CarlWebster.com
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script will use the email server smtp.office365.com on port 587 using SSL,
-\par \hich\af2\dbch\af31505\loch\f2     sending from webster@carlwebster.com, sending to ITGroup@carlwebster.com.
+\par \hich\af2\dbch\af31505\loch\f2     The script use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 
+ the email server smtp.office365.com on port 587 using SSL,}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 
+\hich\af2\dbch\af31505\loch\f2 sending from }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 webster@carlwebster.com, }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 
+\hich\af2\dbch\af31505\loch\f2 and }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 sending to ITGroup@carlwebster.com.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     If the current use\hich\af2\dbch\af31505\loch\f2 r's credentials are not valid to send email,
-\par \hich\af2\dbch\af31505\loch\f2     the user will be prompted to enter valid credentials.
+\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2 an }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 email,}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 
+\hich\af2\dbch\af31505\loch\f2 the }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2 script prompts 
+\par \hich\af2\dbch\af31505\loch\f2     the }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 user to enter \hich\af2\dbch\af31505\loch\f2 valid credentials.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Outputs, by default, to HTML.
 \par \hich\af2\dbch\af31505\loch\f2     Prompts for credentials for the LocalHost RAS Server.
@@ -21574,26 +21614,34 @@ n-device-or-application-to-send-email-using-office-3}}}\sectd \ltrsect\linex0\se
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 10 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\RAS_Inventory_V1.ps1
-\par \hich\af2\dbch\af31505\loch\f2     -SmtpServer smtp.gmail.com
-\par \hich\af2\dbch\af31505\loch\f2     -SmtpPort 587
-\par \hich\af2\dbch\af31505\loch\f2     -UseSSL
-\par \hich\af2\dbch\af31505\loch\f2     -From Webster@CarlWebster.com
-\par \hich\af2\dbch\af31505\loch\f2     -To ITGroup@CarlWebster.com
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\RAS_Inventory_V1.ps1}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 
+\hich\af2\dbch\af31505\loch\f2 -SmtpServer smtp.gmail.com}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 
+\hich\af2\dbch\af31505\loch\f2 -SmtpPort 587}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009 
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2     -UseSSL}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 -From }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428\charrsid15822428 \hich\af2\dbch\af31505\loch\f2 Webster@CarlWebster.com}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 -To ITGroup@CarlWebster.com
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     *** NOTE **\hich\af2\dbch\af31505\loch\f2 *
-\par \hich\af2\dbch\af31505\loch\f2     To send email using a Gmail or g-suite account, you may have to turn ON
-\par \hich\af2\dbch\af31505\loch\f2     the "Less secure app access" option on your account.
+\par \hich\af2\dbch\af31505\loch\f2     *** NOTE ***
+\par \hich\af2\dbch\af31505\loch\f2     To send }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2 an }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 
+email using a Gmail or g-suite account, you may have to turn ON}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 
+\hich\af2\dbch\af31505\loch\f2 the "Less }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 secure app access" op\hich\af2\dbch\af31505\loch\f2 tion on your account.
 \par \hich\af2\dbch\af31505\loch\f2     *** NOTE ***
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script will use the email server smtp.gmail.com on port 587 using SSL,
-\par \hich\af2\dbch\af31505\loch\f2     sending from webster\hich\af2\dbch\af31505\loch\f2 @gmail.com, sending to ITGroup@carlwebster.com.
+\par \hich\af2\dbch\af31505\loch\f2     The script use}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 
+ the email server smtp.gmail.com on port 587 using SSL,}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 
+\hich\af2\dbch\af31505\loch\f2 sending from }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 webster@gmail.com, }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2 
+and }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 sending to ITGroup@carlwebster.com.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send email,
-\par \hich\af2\dbch\af31505\loch\f2     the user will be prompted to enter valid credentials.
-\par 
+\par }\pard \ltrpar\s19\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid15822428 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 
+    If the current user's credentials are not valid to send }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2 an }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428\charrsid5117009 
+\hich\af2\dbch\af31505\loch\f2 email,}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 the }{
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428 \hich\af2\dbch\af31505\loch\f2 script prompts 
+\par \hich\af2\dbch\af31505\loch\f2     the }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15822428\charrsid5117009 \hich\af2\dbch\af31505\loch\f2 user to enter valid credentials.
+\par }\pard \ltrpar\s19\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid5117009 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5117009\charrsid5117009 
 \par \hich\af2\dbch\af31505\loch\f2     Outputs, by default, to HTML.
-\par \hich\af2\dbch\af31505\loch\f2     Prompts for credentials for the LocalHost R\hich\af2\dbch\af31505\loch\f2 AS Server.
+\par \hich\af2\dbch\af31505\loch\f2     Prompts for credentials for the LocalHost RAS Server.
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 RELATED LINKS
@@ -21716,8 +21764,8 @@ fffffffffffffffffdfffffffeffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e5000000000000000000000000f087
-089b6f6ad601feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
+ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e5000000000000000000000000809f
+8a63de35d701feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff0000000000000000000000000000000000000000000000000000
 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff000000000000000000000000000000000000000000000000
 0000000000000000000000000000000000000000000000000105000000000000}}

--- a/RAS_Script_ChangeLog.txt
+++ b/RAS_Script_ChangeLog.txt
@@ -5,3 +5,13 @@
 
 #Version 1.0 released to the community on 5-August-2020
 #
+#Version 1.01 19-Apr-2021
+#	Added a message to the error message for the missing RAS module
+#		Added a link to the V1 ReadMe file
+#	Added the missing License section for published RDSH applications to Text and HTML output
+#	Changed all Write-Verbose statements from Get-Date to Get-Date -Format G as requested by Guy Leech
+#	Changed the font size of Word/PDF tables from 11 to 10 to prevent most word wrapping to multiple lines
+#	Fixed several invalid $Null comparisons
+#	Reorder Parameters in an order recommended by Guy Leech
+#	Updated Function SetWordCellFormat to the latest version
+#	Updated the ReadMe file


### PR DESCRIPTION
#Version 1.01 19-Apr-2021
#	Added a message to the error message for the missing RAS module
#		Added a link to the V1 ReadMe file
#	Added the missing License section for published RDSH applications to Text and HTML output
#	Changed all Write-Verbose statements from Get-Date to Get-Date -Format G as requested by Guy Leech
#	Changed the font size of Word/PDF tables from 11 to 10 to prevent most word wrapping to multiple lines
#	Fixed several invalid $Null comparisons
#	Reorder Parameters in an order recommended by Guy Leech
#	Updated Function SetWordCellFormat to the latest version
#	Updated the ReadMe file